### PR TITLE
Deploy contract arguments

### DIFF
--- a/src/manager/transactions/deploy-contract.cdc
+++ b/src/manager/transactions/deploy-contract.cdc
@@ -1,10 +1,11 @@
 import FlowManager from 0xe03daebed8ca0615
 
-transaction(name:String, code: String, manager: Address) {
+transaction(name:String, code: String, manager: Address ##ARGS-WITH-TYPES##) {
     prepare(acct: AuthAccount){
         acct.contracts.add(
            name: name,
            code: code.decodeHex(),
+           ##ARGS-LIST##
         )
 
         let linkPath = FlowManager.linkContractManager

--- a/src/utils/deploy-code.js
+++ b/src/utils/deploy-code.js
@@ -21,7 +21,6 @@ import { unwrap, sendTransaction } from "./interaction";
 import { getManagerAddress } from "./init-manager";
 import { getContractCode, getTransactionCode } from "./file";
 import { getAccountAddress } from "./create-account";
-import * as sdk from '@onflow/sdk'
 
 export const hexContract = (contract) =>
     Buffer.from(contract, "utf8").toString("hex");

--- a/src/utils/deploy-code.js
+++ b/src/utils/deploy-code.js
@@ -83,11 +83,10 @@ export const deployContract = async ({ to, contractCode, name, args }) => {
 
     code = code.replace("##ARGS-WITH-TYPES##", `, ${argsWithTypes}`)
     code = code.replace("##ARGS-LIST##", argsList)
-
-    console.log({ argsWithTypes, argsList, code })
+  } else {
+    code = code.replace("##ARGS-WITH-TYPES##", ``)
+    code = code.replace("##ARGS-LIST##", '')
   }
-
-  console.log({deployArgs})
 
   const signers = [containerAddress];
 

--- a/src/utils/interaction.js
+++ b/src/utils/interaction.js
@@ -20,16 +20,16 @@ import * as fcl from "@onflow/fcl";
 import * as sdk from "@onflow/sdk";
 import { authorization } from "./crypto";
 
-const unwrap = (arr) => {
+export const unwrap = (arr, convert) => {
   const type = arr[arr.length - 1];
-
-  return arr.slice(0, -1).map((value) => {
-    return sdk.arg(value, type);
-  });
+  return arr.slice(0, -1).map((value) => convert(value, type));
 };
+
 const mapArgs = (args) => {
   return args.reduce((acc, arg) => {
-    const unwrapped = unwrap(arg);
+    const unwrapped = unwrap(arg, (value, type)=>{
+      return sdk.arg(value, type);
+    });
     acc = [...acc, ...unwrapped];
     return acc;
   }, []);


### PR DESCRIPTION
This PR adds code, which will allow to specify arguments, which would be passed into `init` method of the contract, when it's deployed.

Closes #13 