### PR TITLE
Fix import in basic example

### DIFF
--- a/docs/examples/basic.md
+++ b/docs/examples/basic.md
@@ -12,7 +12,7 @@ Let's create `deploy.test.js` file and write some basic test, which would create
 
 ```javascript
 import path from "path";
-import { getAccountAddress } from "flow-js-testing";
+import { getAccountAddress, init } from "flow-js-testing";
 
 const basePath = path.resolve(__dirname, "../cadence");
 


### PR DESCRIPTION
## Description

The basic example uses an `init` function that is not defined.

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-js-testing/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

