### PR TITLE
fix bad links

### DIFF
--- a/docs/accounts.md
+++ b/docs/accounts.md
@@ -26,7 +26,7 @@ Resolves name alias to a Flow address (`0x` prefixed) under the following condit
 
 | Type                                                | Description                              |
 | --------------------------------------------------- | ---------------------------------------- |
-| [Address](https://docs.onflow.org/fcl/api/#address) | `0x` prefixed address of aliased account |
+| [Address](https://docs.onflow.org/fcl/reference/api/#address) | `0x` prefixed address of aliased account |
 
 #### Usage
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,6 @@
 # JS Testing API Reference
 
-> ⚠️ **Required:** Your project must follow the [required structure](#structure) and it must be [initialized](#init) to use the following functions.
+> ⚠️ **Required:** Your project must follow the [required structure](structure.md) and it must be [initialized](#init) to use the following functions.
 
 ## Accounts
 
@@ -21,7 +21,7 @@ Resolves name alias to a Flow address (`0x` prefixed) under the following condit
 
 | Type                                                | Description                              |
 | --------------------------------------------------- | ---------------------------------------- |
-| [Address](https://docs.onflow.org/fcl/api/#address) | `0x` prefixed address of aliased account |
+| [Address](https://docs.onflow.org/fcl/reference/api/#address) | `0x` prefixed address of aliased account |
 
 #### Usage
 
@@ -56,8 +56,8 @@ Props object accepts following fields:
 | Name         | Type                                                | Optional | Description                                                                                                                                     |
 | ------------ | --------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
 | `name`       | string                                              |          | name of the file in `contracts` folder (with `.cdc` extension) and name of the contract (please note those should be the same)                  |
-| `to`         | [Address](https://docs.onflow.org/fcl/api/#address) | ✅       | (optional) account address, where contract will be deployed. If this is not specified, framework will create new account with randomized alias. |
-| `addressMap` | [AddressMap](#AddressMap)                           | ✅       | (optional) object to use for address mapping of existing deployed contracts                                                                     |
+| `to`         | [Address](https://docs.onflow.org/fcl/reference/api/#address) | ✅       | (optional) account address, where contract will be deployed. If this is not specified, framework will create new account with randomized alias. |
+| `addressMap` | [AddressMap](#addressmap)                           | ✅       | (optional) object to use for address mapping of existing deployed contracts                                                                     |
 | `args`       | [Any]                                               | ✅       | (optional) arguments, which will be passed to contract initializer. (optional) if template does not expect any arguments.                       |
 | `update`     | boolean                                             | ✅       | (optional) whether to update deployed contract. Default: `false`                                                                                |
 
@@ -65,7 +65,7 @@ Props object accepts following fields:
 
 | Type                                                              | Description                          |
 | ----------------------------------------------------------------- | ------------------------------------ |
-| [ResponseObject](https://docs.onflow.org/fcl/api/#responseobject) | Result of the deploying transaction. |
+| [ResponseObject](https://docs.onflow.org/fcl/reference/api/#responseobject) | Result of the deploying transaction. |
 
 #### Usage
 
@@ -119,8 +119,8 @@ Props object accepts the following fields:
 | -------------- | --------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | `contractCode` | string                                              |          | string representation of contract                                                                                                    |
 | `name`         | string                                              |          | name of the contract to be deployed. Should be the same as the name of the contract provided in `contractCode`                       |
-| `to`           | [Address](https://docs.onflow.org/fcl/api/#address) | ✅       | account address, where contract will be deployed. If this is not specified, framework will create new account with randomized alias. |
-| `addressMap`   | [AddressMap](#AddressMap)                           | ✅       | object to use for import resolver. Default: `{}`                                                                                     |
+| `to`           | [Address](https://docs.onflow.org/fcl/reference/api/#address) | ✅       | account address, where contract will be deployed. If this is not specified, framework will create new account with randomized alias. |
+| `addressMap`   | [AddressMap](#addressmap)                           | ✅       | object to use for import resolver. Default: `{}`                                                                                     |
 | `args`         | [Any]                                               | ✅       | arguments, which will be passed to contract initializer. Default: `[]`                                                               |
 | `update`       | boolean                                             | ✅       | whether to update deployed contract. Default: `false`                                                                                |
 
@@ -128,7 +128,7 @@ Props object accepts the following fields:
 
 | Type                                                              | Description                          |
 | ----------------------------------------------------------------- | ------------------------------------ |
-| [ResponseObject](https://docs.onflow.org/fcl/api/#responseobject) | Result of the deploying transaction. |
+| [ResponseObject](https://docs.onflow.org/fcl/reference/api/#responseobject) | Result of the deploying transaction. |
 
 #### Usage
 
@@ -190,7 +190,7 @@ Returns address of the account where the contract is currently deployed.
 
 | Type                                                | Description           |
 | --------------------------------------------------- | --------------------- |
-| [Address](https://docs.onflow.org/fcl/api/#address) | `0x` prefixed address |
+| [Address](https://docs.onflow.org/fcl/reference/api/#address) | `0x` prefixed address |
 
 #### Usage
 
@@ -364,7 +364,7 @@ Fetch current FlowToken balance of account specified by address
 
 | Name      | Type                                                | Description                     |
 | --------- | --------------------------------------------------- | ------------------------------- |
-| `address` | [Address](https://docs.onflow.org/fcl/api/#address) | address of the account to check |
+| `address` | [Address](https://docs.onflow.org/fcl/reference/api/#address) | address of the account to check |
 
 #### Returns
 
@@ -409,14 +409,14 @@ Sends transaction to mint specified amount of FLOW token and send it to recipien
 
 | Name        | Type                                                | Description                                                |
 | ----------- | --------------------------------------------------- | ---------------------------------------------------------- |
-| `recipient` | [Address](https://docs.onflow.org/fcl/api/#address) | address of the account to check                            |
+| `recipient` | [Address](https://docs.onflow.org/fcl/reference/api/#address) | address of the account to check                            |
 | `amount`    | string                                              | UFix64 amount of FLOW tokens to mint and send to recipient |
 
 #### Returns
 
 | Type                                                              | Description        |
 | ----------------------------------------------------------------- | ------------------ |
-| [ResponseObject](https://docs.onflow.org/fcl/api/#responseobject) | Transaction result |
+| [ResponseObject](https://docs.onflow.org/fcl/reference/api/#responseobject) | Transaction result |
 
 #### Usage
 
@@ -608,13 +608,13 @@ Ensure transaction does not throw and sealed.
 
 | Name | Type                        | Description                                          |
 | ---- | --------------------------- | ---------------------------------------------------- |
-| `ix` | [Interaction](#Interaction) | interaction, either in form of a Promise or function |
+| `ix` | [Interaction](#interaction) | interaction, either in form of a Promise or function |
 
 #### Returns
 
 | Type                                                              | Description        |
 | ----------------------------------------------------------------- | ------------------ |
-| [ResponseObject](https://docs.onflow.org/fcl/api/#responseobject) | Transaction result |
+| [ResponseObject](https://docs.onflow.org/fcl/reference/api/#responseobject) | Transaction result |
 
 #### Usage
 
@@ -679,13 +679,13 @@ Ensure interaction throws an error. You might want to use this to test incorrect
 
 | Name | Type                        | Description                                          |
 | ---- | --------------------------- | ---------------------------------------------------- |
-| `ix` | [Interaction](#Interaction) | transaction, either in form of a Promise or function |
+| `ix` | [Interaction](#interaction) | transaction, either in form of a Promise or function |
 
 #### Returns
 
 | Type                                                              | Description        |
 | ----------------------------------------------------------------- | ------------------ |
-| [ResponseObject](https://docs.onflow.org/fcl/api/#responseobject) | Transaction result |
+| [ResponseObject](https://docs.onflow.org/fcl/reference/api/#responseobject) | Transaction result |
 
 #### Usage
 
@@ -750,7 +750,7 @@ Ensure interaction resolves without throwing errors.
 
 | Name | Type                        | Description                                          |
 | ---- | --------------------------- | ---------------------------------------------------- |
-| `ix` | [Interaction](#Interaction) | interaction, either in form of a Promise or function |
+| `ix` | [Interaction](#interaction) | interaction, either in form of a Promise or function |
 
 #### Returns
 
@@ -806,7 +806,7 @@ account, read public value of the contract or ensure that user has specific reso
 
 We abstract this interaction into single method called `executeScript`. Method have 2 different signatures.
 
-> ⚠️ **Required:** Your project must follow the [required structure](https://docs.onflow.org/flow-js-testing/structure) it must be [initialized](https://docs.onflow.org/flow-js-testing/init) to use the following functions.
+> ⚠️ **Required:** Your project must follow the [required structure](structure.md) it must be [initialized](init.md) to use the following functions.
 
 ### `executeScript(props)`
 
@@ -821,7 +821,7 @@ Provides explicit control over how you pass values.
 | `code`         | string                                                                        | ✅       | string representation of Cadence script                                                    |
 | `name`         | string                                                                        | ✅       | name of the file in `scripts` folder to use (sans `.cdc` extension)                        |
 | `args`         | array                                                                         | ✅       | an array of arguments to pass to script. Optional if script does not expect any arguments. |
-| `transformers` | array[[CadenceTransformer](https://docs.onflow.org/fcl/api/#codetransformer)] | ✅       | an array of operators to modify the code, before submitting it to network                  |
+| `transformers` | array[[CadenceTransformer](#cadencetransformer)] | ✅       | an array of operators to modify the code, before submitting it to network                  |
 
 > ⚠️ **Required:** Either `code` or `name` field shall be specified. Method will throw an error if both of them are empty.
 > If `name` field provided, framework will source code from file and override value passed via `code` field.
@@ -830,7 +830,7 @@ Provides explicit control over how you pass values.
 
 | Type                                                              | Description   |
 | ----------------------------------------------------------------- | ------------- |
-| [ResponseObject](https://docs.onflow.org/fcl/api/#responseobject) | Script result |
+| [ResponseObject](https://docs.onflow.org/fcl/reference/api/#responseobject) | Script result |
 
 #### Usage
 
@@ -889,7 +889,7 @@ Cadence files.
 
 | Type                                                              | Description   |
 | ----------------------------------------------------------------- | ------------- |
-| [ResponseObject](https://docs.onflow.org/fcl/api/#responseobject) | Script result |
+| [ResponseObject](https://docs.onflow.org/fcl/reference/api/#responseobject) | Script result |
 
 #### Usage
 
@@ -930,7 +930,7 @@ main();
 Another common case is necessity to mutate network state - sending tokens from one account to another, minting new
 NFT, etc. Framework provides `sendTransaction` method to achieve this. This method has 2 different signatures.
 
-> ⚠️ **Required:** Your project must follow the [required structure](https://docs.onflow.org/flow-js-testing/structure) it must be [initialized](https://docs.onflow.org/flow-js-testing/init) to use the following functions.
+> ⚠️ **Required:** Your project must follow the [required structure](structure.md) it must be [initialized](init.md) to use the following functions.
 
 ### `sendTransaction(props)`
 
@@ -946,9 +946,9 @@ Provides explicit control over how you pass values.
 | `code`         | string                                                                        | ✅       | string representation of Cadence transaction                                                         |
 | `name`         | string                                                                        | ✅       | name of the file in `transaction` folder to use (sans `.cdc` extension)                              |
 | `args`         | [Any]                                                                         | ✅       | an array of arguments to pass to transaction. Optional if transaction does not expect any arguments. |
-| `signers`      | [Address]                                                                     | ✅       | an array of [Address](https://docs.onflow.org/fcl/api/#address) representing transaction autorizers  |
-| `addressMap`   | [AddressMap](#AddressMap)                                                     | ✅       | name/address map to use as lookup table for addresses in import statements                           |
-| `transformers` | array[[CadenceTransformer](https://docs.onflow.org/fcl/api/#codetransformer)] | ✅       | an array of operators to modify the code, before submitting it to network                            |
+| `signers`      | [Address]                                                                     | ✅       | an array of [Address](https://docs.onflow.org/fcl/reference/api/#address) representing transaction autorizers  |
+| `addressMap`   | [AddressMap](#addressmap)                                                     | ✅       | name/address map to use as lookup table for addresses in import statements                           |
+| `transformers` | array[[CadenceTransformer](#cadencetransformer)] | ✅       | an array of operators to modify the code, before submitting it to network                            |
 
 > ⚠️ **Required:** Either `code` or `name` field shall be specified. Method will throw an error if both of them are empty.
 > If `name` field provided, framework will source code from file and override value passed via `code` field.
@@ -962,7 +962,7 @@ Provides explicit control over how you pass values.
 
 | Type                                                              | Description        |
 | ----------------------------------------------------------------- | ------------------ |
-| [ResponseObject](https://docs.onflow.org/fcl/api/#responseobject) | Interaction result |
+| [ResponseObject](https://docs.onflow.org/fcl/reference/api/#responseobject) | Interaction result |
 
 #### Usage
 
@@ -1015,14 +1015,14 @@ Cadence files.
 | Name      | Type   | Optional | Description                                                                                          |
 | --------- | ------ | -------- | ---------------------------------------------------------------------------------------------------- |
 | `name`    | string | ✅       | name of the file in `transaction` folder to use (sans `.cdc` extension)                              |
-| `signers` | array  | ✅       | an array of [Address](https://docs.onflow.org/fcl/api/#address) representing transaction autorizers  |
+| `signers` | array  | ✅       | an array of [Address](https://docs.onflow.org/fcl/reference/api/#address) representing transaction autorizers  |
 | `args`    | [Any]  | ✅       | an array of arguments to pass to transaction. Optional if transaction does not expect any arguments. |
 
 #### Returns
 
 | Type                                                              | Description        |
 | ----------------------------------------------------------------- | ------------------ |
-| [ResponseObject](https://docs.onflow.org/fcl/api/#responseobject) | Interaction result |
+| [ResponseObject](https://docs.onflow.org/fcl/reference/api/#responseobject) | Interaction result |
 
 #### Usage
 
@@ -1070,7 +1070,7 @@ Returns Cadence template as string with addresses replaced using addressMap
 | Name         | Type                      | Optional | Description                                                                                               |
 | ------------ | ------------------------- | -------- | --------------------------------------------------------------------------------------------------------- |
 | `file`       | string                    |          | relative (to the place from where the script was called) or absolute path to the file containing the code |
-| `addressMap` | [AddressMap](#AddressMap) | ✅       | object to use for address mapping of existing deployed contracts. Default: `{}`                           |
+| `addressMap` | [AddressMap](#addressmap) | ✅       | object to use for address mapping of existing deployed contracts. Default: `{}`                           |
 | `byAddress`  | boolean                   | ✅       | whether addressMap is `{name:address}` or `{address:address}` type. Default: `false`                      |
 
 #### Returns
@@ -1105,7 +1105,7 @@ Returns Cadence template from file with `name` in `_basepath_/contracts` folder
 | Name         | Type                      | Optional | Description                                                      |
 | ------------ | ------------------------- | -------- | ---------------------------------------------------------------- |
 | `name`       | string                    |          | name of the contract template                                    |
-| `addressMap` | [AddressMap](#AddressMap) | ✅       | object to use for address mapping of existing deployed contracts |
+| `addressMap` | [AddressMap](#addressmap) | ✅       | object to use for address mapping of existing deployed contracts |
 
 #### Returns
 
@@ -1151,7 +1151,7 @@ Returns Cadence template from file with `name` in `_basepath_/transactions` fold
 | Name         | Type                      | Optional | Description                                                      |
 | ------------ | ------------------------- | -------- | ---------------------------------------------------------------- |
 | `name`       | string                    |          | name of the transaction template                                 |
-| `addressMap` | [AddressMap](#AddressMap) | ✅       | object to use for address mapping of existing deployed contracts |
+| `addressMap` | [AddressMap](#addressmap) | ✅       | object to use for address mapping of existing deployed contracts |
 
 #### Returns
 
@@ -1198,7 +1198,7 @@ Returns Cadence template from file with `name` in `_basepath_/scripts` folder
 | Name         | Type                      | Optional | Description                                                      |
 | ------------ | ------------------------- | -------- | ---------------------------------------------------------------- |
 | `name`       | string                    |          | name of the script template                                      |
-| `addressMap` | [AddressMap](#AddressMap) | ✅       | object to use for address mapping of existing deployed contracts |
+| `addressMap` | [AddressMap](#addressmap) | ✅       | object to use for address mapping of existing deployed contracts |
 
 #### Returns
 
@@ -1240,7 +1240,7 @@ main();
 
 ### `AddressMap`
 
-Object to use for address mapping of existing deployed contracts. Key shall be `string` and value shall be [Address](https://docs.onflow.org/fcl/api/#address)
+Object to use for address mapping of existing deployed contracts. Key shall be `string` and value shall be [Address](https://docs.onflow.org/fcl/reference/api/#address)
 
 #### Example
 

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -4,7 +4,7 @@ sidebar_title: Contracts
 description: How to manage contracts
 ---
 
-> ⚠️ **Required:** Your project must follow the [required structure](https://docs.onflow.org/flow-js-testing/structure) and it must be [initialized](https://docs.onflow.org/flow-js-testing/init) to use the following functions.
+> ⚠️ **Required:** Your project must follow the [required structure](structure.md) and it must be [initialized](init.md) to use the following functions.
 
 ## `deployContractByName(props)`
 
@@ -17,8 +17,8 @@ Props object accepts the following fields:
 | Name         | Type                                                | Optional | Description                                                                                                                                     |
 | ------------ | --------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
 | `name`       | string                                              |          | name of the file in `contracts` folder (sans `.cdc` extension) and name of the contract (please note those should be the same)                  |
-| `to`         | [Address](https://docs.onflow.org/fcl/api/#address) | ✅       | (optional) account address, where contract will be deployed. If this is not specified, framework will create new account with randomized alias. |
-| `addressMap` | [AdressMap](types/#AddressMap)                      | ✅       | (optional) object to use for address mapping of existing deployed contracts                                                                     |
+| `to`         | [Address](https://docs.onflow.org/fcl/reference/api/#address) | ✅       | (optional) account address, where contract will be deployed. If this is not specified, framework will create new account with randomized alias. |
+| `addressMap` | [AddressMap](api.md#addressmap)                      | ✅       | (optional) object to use for address mapping of existing deployed contracts                                                                     |
 | `args`       | [Any]                                               | ✅       | (optional) arguments, which will be passed to contract initializer. (optional) if template does not expect any arguments.                       |
 | `update`     | boolean                                             | ✅       | (optional) whether to update deployed contract. Default: `false`                                                                                |
 
@@ -26,7 +26,7 @@ Props object accepts the following fields:
 
 | Type                                                              | Description                          |
 | ----------------------------------------------------------------- | ------------------------------------ |
-| [ResponseObject](https://docs.onflow.org/fcl/api/#responseobject) | Result of the deploying transaction. |
+| [ResponseObject](https://docs.onflow.org/fcl/reference/api/#responseobject) | Result of the deploying transaction. |
 
 Usage:
 
@@ -80,8 +80,8 @@ Props object accepts the following fields:
 | -------------- | --------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | `contractCode` | string                                              |          | string representation of contract                                                                                                    |
 | `name`         | string                                              |          | name of the contract to be deployed. Should be the same as the name of the contract provided in `contractCode`                       |
-| `to`           | [Address](https://docs.onflow.org/fcl/api/#address) | ✅       | account address, where contract will be deployed. If this is not specified, framework will create new account with randomized alias. |
-| `addressMap`   | [AdressMap](types/#AddressMap)                                               | ✅       | object to use for import resolver. Default: `{}`                                                                                     |
+| `to`           | [Address](https://docs.onflow.org/fcl/reference/api/#address) | ✅       | account address, where contract will be deployed. If this is not specified, framework will create new account with randomized alias. |
+| `addressMap`   | [AddressMap](api.md#addressmap)                                               | ✅       | object to use for import resolver. Default: `{}`                                                                                     |
 | `args`         | [Any]                                               | ✅       | arguments, which will be passed to contract initializer. Default: `[]`                                                               |
 | `update`       | boolean                                             | ✅       | whether to update deployed contract. Default: `false`                                                                                |
 

--- a/docs/execute-scripts.md
+++ b/docs/execute-scripts.md
@@ -8,7 +8,7 @@ It is often the case that you need to query the current state of the network. Fo
 account, read public values of a contract or ensure that a user has a specific resource in their storage.
 We abstract this interaction into a single method called `executeScript`. Method have 2 different signatures.
 
-> ⚠️ **Required:** Your project must follow the [required structure](https://docs.onflow.org/flow-js-testing/structure) it must be [initialized](https://docs.onflow.org/flow-js-testing/init) to use the following functions.
+> ⚠️ **Required:** Your project must follow the [required structure](structure.md) it must be [initialized](init.md) to use the following functions.
 
 ## `executeScript(props)`
 

--- a/docs/flow-token.md
+++ b/docs/flow-token.md
@@ -15,7 +15,7 @@ Returns current FLOW token balance of the specified account.
 
 | Name      | Type                                                | Description                     |
 | --------- | --------------------------------------------------- | ------------------------------- |
-| `address` | [Address](https://docs.onflow.org/fcl/api/#address) | address of the account to check |
+| `address` | [Address](https://docs.onflow.org/fcl/reference/api/#address) | address of the account to check |
 
 #### Returns
 
@@ -60,7 +60,7 @@ Sends transaction to mint the specified amount of FLOW and send it to recipient.
 
 | Name        | Type                                                | Description                                                |
 | ----------- | --------------------------------------------------- | ---------------------------------------------------------- |
-| `recipient` | [Address](https://docs.onflow.org/fcl/api/#address) | address of the account to check                            |
+| `recipient` | [Address](https://docs.onflow.org/fcl/reference/api/#address) | address of the account to check                            |
 | `amount`    | string                                              | UFix64 amount of FLOW tokens to mint and send to recipient |
 
 #### Usage

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ Flow Javascript Testing Framework aims to reduce said complexity by providing a 
 you easily:
 
 - [Start and stop new emulator instance](emulator.md)
-- [Deploy contracts](contracts.md)
+- [Deploy contracts](contracts)
 - [Create new accounts](accounts.md)
 - [Send transactions](send-transactions.md)
 - [Execute scripts](execute-scripts.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,12 +13,12 @@ Writing smart contracts can be complex. With the help of the Cadence language se
 Flow Javascript Testing Framework aims to reduce said complexity by providing a set of helpful methods allowing
 you easily:
 
-- [Start and stop new emulator instance](#emulator)
-- [Deploy contracts](#contracts)
-- [Create new accounts](#accounts)
-- [Send transactions](#send-transactions)
-- [Execute scripts](#execute-scripts)
-- [query balances and mint FLOW for specific account](#flow-token)
+- [Start and stop new emulator instance](emulator.md)
+- [Deploy contracts](contracts.md)
+- [Create new accounts](accounts.md)
+- [Send transactions](send-transactions.md)
+- [Execute scripts](execute-scripts.md)
+- [query balances and mint FLOW for specific account](flow-token.md)
 
 Framework will handle creating and managing the private keys you need to sign transactions, and try to automatically resolve import statements (provided, that necessary contracts deployed), so you can focus on writing Cadence code.
 
@@ -29,4 +29,4 @@ framework are agnostic of any other testing library - except for the ones using 
 
 ## Installation
 
-Follow [these steps](https://docs.onflow.org/flow-js-testing/install) to add framework to your project.
+Follow [these steps](install.md) to add framework to your project.

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ Flow Javascript Testing Framework aims to reduce said complexity by providing a 
 you easily:
 
 - [Start and stop new emulator instance](emulator.md)
-- [Deploy contracts](contracts)
+- [Deploy contracts](contracts.md)
 - [Create new accounts](accounts.md)
 - [Send transactions](send-transactions.md)
 - [Execute scripts](execute-scripts.md)

--- a/docs/jest-helpers.md
+++ b/docs/jest-helpers.md
@@ -15,13 +15,13 @@ Ensure transaction did not throw and was sealed.
 
 | Name | Type                        | Description                                          |
 | ---- | --------------------------- | ---------------------------------------------------- |
-| `ix` | [Interaction](types/#Interaction)  | interaction, either in form of a Promise or function |
+| `ix` | [Interaction](api.md#interaction)  | interaction, either in form of a Promise or function |
 
 #### Returns
 
 | Type                                    | Description        |
 | --------------------------------------- | ------------------ |
-| [ResponseObject](https://docs.onflow.org/fcl/api/#responseobject) | Transaction result |
+| [ResponseObject](https://docs.onflow.org/fcl/reference/api/#responseobject) | Transaction result |
 
 #### Usage
 
@@ -87,13 +87,13 @@ Returns Promise, which contains result, when resolved.
 
 | Name | Type                        | Description                                          |
 | ---- | --------------------------- | ---------------------------------------------------- |
-| `ix` | [Interaction](types/#Interaction) | transaction, either in form of a Promise or function |
+| `ix` | [Interaction](api.md#interaction) | transaction, either in form of a Promise or function |
 
 #### Returns
 
 | Type                                    | Description        |
 | --------------------------------------- | ------------------ |
-| [ResponseObject](https://docs.onflow.org/fcl/api/#responseobject) | Transaction result |
+| [ResponseObject](https://docs.onflow.org/fcl/reference/api/#responseobject) | Transaction result |
 
 #### Usage
 
@@ -158,13 +158,13 @@ Ensure interaction resolves without throwing errors.
 
 | Name | Type                        | Description                                          |
 | ---- | --------------------------- | ---------------------------------------------------- |
-| `ix` | [Interaction](types/#Interaction) | interaction, either in form of a Promise or function |
+| `ix` | [Interaction](api.md#interaction) | interaction, either in form of a Promise or function |
 
 #### Returns
 
 | Type                                    | Description        |
 | --------------------------------------- | ------------------ |
-| [ResponseObject](https://docs.onflow.org/fcl/api/#responseobject) | Transaction result |
+| [ResponseObject](https://docs.onflow.org/fcl/reference/api/#responseobject) | Transaction result |
 
 #### Usage
 

--- a/docs/send-transactions.md
+++ b/docs/send-transactions.md
@@ -6,7 +6,7 @@ description: How to send transactions
 
 Another common case is interactions that mutate network state - sending tokens from one account to another, minting new NFT, etc. Framework provides `sendTransaction` method to achieve this. This method have 2 different signatures.
 
-> ⚠️ **Required:** Your project must follow the [required structure](https://docs.onflow.org/flow-js-testing/structure) it must be [initialized](https://docs.onflow.org/flow-js-testing/init) to use the following functions.
+> ⚠️ **Required:** Your project must follow the [required structure](structure.md) it must be [initialized](init.md) to use the following functions.
 
 ## `sendTransaction(props)`
 
@@ -23,7 +23,7 @@ Provides explicit control over how you pass values.
 | `name`       | string                         | ✅       | name of the file in `transaction` folder to use (sans `.cdc` extension)                              |
 | `args`       | [Any]                          | ✅       | an array of arguments to pass to transaction. Optional if transaction does not expect any arguments. |
 | `signers`    | [Address]                      | ✅       | an array of [Address](#Address) representing transaction autorizers                                  |
-| `addressMap` | [AdressMap](types/#AddressMap) | ✅       | name/address map to use as lookup table for addresses in import statements                           |
+| `addressMap` | [AddressMap](api.md#addressmap) | ✅       | name/address map to use as lookup table for addresses in import statements                           |
 
 > ⚠️ **Required:** Either `code` or `name` field shall be specified. Method will throw an error if both of them are empty.
 > If `name` field provided, framework will source code from file and override value passed via `code` field.

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -5,7 +5,7 @@ description: How to structure your Cadence files
 ---
 
 Currently, Framework expects a specific hierarchy of files inside your base directory.
-There are no rules that enforce the name of the ase directory, but there should be 3 folders inside with names:
+There are no rules that enforce the name of the base directory, but there should be 3 folders inside with names:
 
 - `contracts`
 - `transactions`
@@ -14,7 +14,7 @@ There are no rules that enforce the name of the ase directory, but there should 
 Each of those folders shall store corresponding templates types, i.e. `contracts` folder stores contract templates.
 
 You can have nested folders inside them, but templates in each of those root folders would be treated as of certain
-type. For example:
+type.
 
 ## Usage
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -16,7 +16,7 @@ Returns Cadence template as string with addresses replaced using addressMap
 | Name         | Type                           | Optional | Description                                                                                               |
 | ------------ | ------------------------------ | -------- | --------------------------------------------------------------------------------------------------------- |
 | `file`       | string                         |          | relative (to the place from where the script was called) or absolute path to the file containing the code |
-| `addressMap` | [AddressMap](./api#addressmap) | ✅       | object to use for address mapping of existing deployed contracts. Default: `{}`                           |
+| `addressMap` | [AddressMap](./api.md#addressmap) | ✅       | object to use for address mapping of existing deployed contracts. Default: `{}`                           |
 | `byAddress`  | boolean                        | ✅       | whether addressMap is `{name:address}` or `{address:address}` type. Default: `false`                      |
 
 #### Returns

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -51,7 +51,7 @@ Returns Cadence template from file with `name` in `_basepath_/contracts` folder
 | Name         | Type                           | Optional | Description                                                      |
 | ------------ | ------------------------------ | -------- | ---------------------------------------------------------------- |
 | `name`       | string                         |          | name of the contract template                                    |
-| `addressMap` | [AddressMap](api.md#addressmap) | ✅       | object to use for address mapping of existing deployed contracts |
+| `addressMap` | [AddressMap](./api.md#addressmap) | ✅       | object to use for address mapping of existing deployed contracts |
 
 #### Returns
 
@@ -97,7 +97,7 @@ Returns Cadence template from file with `name` in `_basepath_/transactions` fold
 | Name         | Type                           | Optional | Description                                                      |
 | ------------ | ------------------------------ | -------- | ---------------------------------------------------------------- |
 | `name`       | string                         |          | name of the transaction template                                 |
-| `addressMap` | [AddressMap](api.md#addressmap) | ✅       | object to use for address mapping of existing deployed contracts |
+| `addressMap` | [AddressMap](./api.md#addressmap) | ✅       | object to use for address mapping of existing deployed contracts |
 
 #### Returns
 
@@ -144,7 +144,7 @@ Returns Cadence template from file with `name` in `_basepath_/scripts` folder
 | Name         | Type                           | Optional | Description                                                      |
 | ------------ | ------------------------------ | -------- | ---------------------------------------------------------------- |
 | `name`       | string                         |          | name of the script template                                      |
-| `addressMap` | [AddressMap](api.md#addressmap) | ✅       | object to use for address mapping of existing deployed contracts |
+| `addressMap` | [AddressMap](./api.md#addressmap) | ✅       | object to use for address mapping of existing deployed contracts |
 
 #### Returns
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -16,7 +16,7 @@ Returns Cadence template as string with addresses replaced using addressMap
 | Name         | Type                           | Optional | Description                                                                                               |
 | ------------ | ------------------------------ | -------- | --------------------------------------------------------------------------------------------------------- |
 | `file`       | string                         |          | relative (to the place from where the script was called) or absolute path to the file containing the code |
-| `addressMap` | [AdressMap](types/#AddressMap) | ✅       | object to use for address mapping of existing deployed contracts. Default: `{}`                           |
+| `addressMap` | [AddressMap](./api#addressmap) | ✅       | object to use for address mapping of existing deployed contracts. Default: `{}`                           |
 | `byAddress`  | boolean                        | ✅       | whether addressMap is `{name:address}` or `{address:address}` type. Default: `false`                      |
 
 #### Returns
@@ -51,7 +51,7 @@ Returns Cadence template from file with `name` in `_basepath_/contracts` folder
 | Name         | Type                           | Optional | Description                                                      |
 | ------------ | ------------------------------ | -------- | ---------------------------------------------------------------- |
 | `name`       | string                         |          | name of the contract template                                    |
-| `addressMap` | [AdressMap](types/#AddressMap) | ✅       | object to use for address mapping of existing deployed contracts |
+| `addressMap` | [AddressMap](api.md#addressmap) | ✅       | object to use for address mapping of existing deployed contracts |
 
 #### Returns
 
@@ -97,7 +97,7 @@ Returns Cadence template from file with `name` in `_basepath_/transactions` fold
 | Name         | Type                           | Optional | Description                                                      |
 | ------------ | ------------------------------ | -------- | ---------------------------------------------------------------- |
 | `name`       | string                         |          | name of the transaction template                                 |
-| `addressMap` | [AdressMap](types/#AddressMap) | ✅       | object to use for address mapping of existing deployed contracts |
+| `addressMap` | [AddressMap](api.md#addressmap) | ✅       | object to use for address mapping of existing deployed contracts |
 
 #### Returns
 
@@ -144,7 +144,7 @@ Returns Cadence template from file with `name` in `_basepath_/scripts` folder
 | Name         | Type                           | Optional | Description                                                      |
 | ------------ | ------------------------------ | -------- | ---------------------------------------------------------------- |
 | `name`       | string                         |          | name of the script template                                      |
-| `addressMap` | [AdressMap](types/#AddressMap) | ✅       | object to use for address mapping of existing deployed contracts |
+| `addressMap` | [AddressMap](api.md#addressmap) | ✅       | object to use for address mapping of existing deployed contracts |
 
 #### Returns
 

--- a/docs/types.md
+++ b/docs/types.md
@@ -1,6 +1,6 @@
 ### `AddressMap`
 
-Object to use for address mapping of existing deployed contracts. Key shall be `string` and value shall be [Address](https://docs.onflow.org/fcl/api/#address)
+Object to use for address mapping of existing deployed contracts. Key shall be `string` and value shall be [Address](https://docs.onflow.org/fcl/reference/api/#address)
 
 #### Example
 


### PR DESCRIPTION
use relative links whenever possible (instead of using docs.onflow.org), to address issue https://github.com/onflow/flow-js-testing/issues/59


## Description
Each Flow tool/library should be able to create links using Markdown relative paths. This was not functioning previously, though it will work once issue https://github.com/onflow/flow/issues/704 is fixed

______

For contributor use:

- [ ] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-js-testing/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

