### PR TITLE
make API call to getBlock() to determine if emulator is fully up

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flow-js-testing",
-  "version": "0.2.1",
+  "version": "0.2.2-alpha.3",
   "description": "This package will expose a set of utility methods, to allow Cadence code testing with libraries like Jest",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description
Change the way flow-js-testing detects emulator status: from reading emulator logging to making an API call to /live endpoint
Related issue: https://github.com/onflow/flow-js-testing/issues/61

## tests
- create a simple test project, verified tests are working there 
- introduce long delay in emulator startup, verified tests are working
- introduce long delay in emulator startup, set a short timeout for tests, verify test will fail due to timeout

______

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-js-testing/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

