### PR TITLE
Remove emulator console logs

### DIFF
--- a/src/emulator.js
+++ b/src/emulator.js
@@ -96,7 +96,7 @@ export class Emulator {
           clearInterval(internalId);
           this.initialized = true;
           resolve(true);
-        } catch (err) {}  // eslint-disable-line no-unused-vars
+        } catch (err) {}  // eslint-disable-line no-unused-vars, no-empty
       }
       internalId = setInterval(checkLiveness, 100);
 

--- a/src/emulator.js
+++ b/src/emulator.js
@@ -93,13 +93,10 @@ export class Emulator {
         try {
           await send(build([getBlock(false)])).then(decode);
 
-          console.log("Flow emulator is ready")
           clearInterval(internalId);
           this.initialized = true;
           resolve(true);
-        } catch (err) {  // eslint-disable-line no-unused-vars
-          console.log("Flow emulator not ready yet")
-        }
+        } catch (err) {}  // eslint-disable-line no-unused-vars
       }
       internalId = setInterval(checkLiveness, 100);
 


### PR DESCRIPTION
## Description

This PR removes two console log statements that can create noise in testing logs. Example:

<img width="513" alt="Screen Shot 2022-01-16 at 8 21 16 PM" src="https://user-images.githubusercontent.com/2547035/149708321-8be7ca81-b0a0-4267-8c79-26ea1c519a50.png">
