### PR TITLE
Fixed example 10

### DIFF
--- a/examples/10-templates.js
+++ b/examples/10-templates.js
@@ -19,16 +19,16 @@ import {
     Profile: "0xf8d6e0586b0a20c7",
   };
 
-  const [withPath] = await getTemplate("./cadence/scripts/replace-address.cdc", addressMap);
+  const withPath = await getTemplate("./cadence/scripts/replace-address.cdc", addressMap);
   console.log({ withPath });
 
-  const [contractTemplate] = await getContractCode({ name: "Greeting", addressMap });
+  const contractTemplate = await getContractCode({ name: "Greeting", addressMap });
   console.log({ contractTemplate });
 
-  const [transactionTemplate] = await getTransactionCode({ name: "log-signers", addressMap });
+  const transactionTemplate = await getTransactionCode({ name: "log-signers", addressMap });
   console.log({ transactionTemplate });
 
-  const [scriptTemplate] = await getScriptCode({ name: "log-args", addressMap });
+  const scriptTemplate = await getScriptCode({ name: "log-args", addressMap });
   console.log({ scriptTemplate });
 
   await emulator.stop();


### PR DESCRIPTION
Closes #???

## Description

Example used functions in the following way:
```js
const [returnValue] = await someFunction();
console.log({ returnValue });
```

Which was incorrect, given the fact that the return value is a string and not an array.

______

For contributor use:

- [x] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-js-testing/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 

