### PR TITLE
Throw errors on emulator startup correctly

### DIFF
--- a/test/emulator.test.js
+++ b/test/emulator.test.js
@@ -4,21 +4,21 @@ describe("emulator - logging", () => {
   it("shall format single info line properly", async () => {
     const msg = "Hello, world";
 
-    const output = emulator.parseDataBuffer(msg);
-    expect(output.msg).toBe(msg)
-    expect(output.level).toBe("parser")
+    const [output] = emulator.parseDataBuffer(msg);
+    expect(output.msg).toBe(msg);
+    expect(output.level).toBe("parser");
   });
 
-  it("shall format logged message", ()=>{
+  it("shall format logged message", () => {
     const input = {
       time: "2021-09-28T15:06:56+03:00",
       level: "info",
       msg: "🌱  Starting gRPC server on port 3569",
-      port: 3659
-    }
-    const msg = JSON.stringify(input)
-    const output = emulator.parseDataBuffer(msg);
-    expect(output.level).toBe(input.level)
-    expect(output.msg).toBe(input.msg)
-  })
+      port: 3659,
+    };
+    const msg = JSON.stringify(input);
+    const [output] = emulator.parseDataBuffer(msg);
+    expect(output.level).toBe(input.level);
+    expect(output.msg).toBe(input.msg);
+  });
 });


### PR DESCRIPTION
Closes #108 #89

## Description

Adds an EmulatorError exception for emulator.start() so that error is more explicit (i.e. if emulator is already running, it is obvious and the CLI error shows to the user)