### PR TITLE
Allow for custom transaction signers to be provided

### DIFF
--- a/.changeset/clean-oranges-hammer.md
+++ b/.changeset/clean-oranges-hammer.md
@@ -1,0 +1,5 @@
+---
+"@onflow/flow-js-testing": minor
+---
+
+Allow custom transaction signers to be provided as object with `addr`, `privateKey`, `keyId`, `hashAlgorithm` keys as an alternative to supplying merely the signer's account address and having Flow JS Testing determine the rest. This allows for more complex transaction authorizers. See [documentation for examples](/docs/send-transactions.md).

--- a/dev-test/deploy.test.js
+++ b/dev-test/deploy.test.js
@@ -122,7 +122,7 @@ describe("interactions - sendTransaction", () => {
       `,
       })
     )
-    expect(numberResult).toBe(number)
+    expect(numberResult).toBe(String(number))
     expect(numberErr).toBe(null)
   })
 })

--- a/dev-test/imports.test.js
+++ b/dev-test/imports.test.js
@@ -45,11 +45,11 @@ describe("import resolver", () => {
 
     const addressMap = await resolveImports(code)
     const Registry = await getServiceAddress()
-    const [first] = addressMap["First"]
-    const [second] = addressMap["Second"]
-    expect(first).toBe(Registry)
-    expect(second).toBe(Registry)
-    expect(addressMap["FungibleToken"]).toBe(defaultsByName.FungibleToken)
-    expect(addressMap["FlowToken"]).toBe(defaultsByName.FlowToken)
+
+    const {First, Second, FungibleToken, FlowToken} = addressMap
+    expect(First).toBe(Registry)
+    expect(Second).toBe(Registry)
+    expect(FungibleToken).toBe(defaultsByName.FungibleToken)
+    expect(FlowToken).toBe(defaultsByName.FlowToken)
   })
 })

--- a/dev-test/interaction.test.js
+++ b/dev-test/interaction.test.js
@@ -1,3 +1,5 @@
+/* eslint-disable jest/expect-expect */
+import {config} from "@onflow/fcl"
 import path from "path"
 import {
   emulator,
@@ -56,6 +58,62 @@ describe("interactions - sendTransaction", () => {
       `
       return sendTransaction({code})
     })
+  })
+
+  test("sendTransaction - shall pass with signer address", async () => {
+    const Alice = await getAccountAddress("Alice")
+
+    const code = `
+      transaction{
+        prepare(signer: AuthAccount){
+          assert(signer.address == ${Alice}, message: "Signer address must be equal to Alice's Address")
+        }
+      }
+    `
+    const signers = [Alice]
+
+    await shallPass(sendTransaction({code, signers}))
+  })
+
+  test("sendTransaction - shall pass with signer object using default private key", async () => {
+    const Alice = await getAccountAddress("Alice")
+
+    const code = `
+      transaction{
+        prepare(signer: AuthAccount){
+          assert(signer.address == ${Alice}, message: "Signer address must be equal to Alice's Address")
+        }
+      }
+    `
+    const signers = [
+      {
+        addr: Alice,
+        keyId: 0,
+      },
+    ]
+
+    await shallPass(sendTransaction({code, signers}))
+  })
+
+  test("sendTransaction - shall pass with signer object using custom private key", async () => {
+    const Alice = await getAccountAddress("Alice")
+
+    const code = `
+      transaction{
+        prepare(signer: AuthAccount){
+          assert(signer.address == ${Alice}, message: "Signer address must be equal to Alice's Address")
+        }
+      }
+    `
+    const signers = [
+      {
+        addr: Alice,
+        keyId: 0,
+        privateKey: await config().get("PRIVATE_KEY"),
+      },
+    ]
+
+    await shallPass(sendTransaction({code, signers}))
   })
 
   test("sendTransaction - argument mapper - basic", async () => {
@@ -167,7 +225,7 @@ describe("interactions - executeScript", () => {
   test("executeScript - shall pass with short notation", async () => {
     const [result, err] = await shallResolve(executeScript("log-message"))
     expect(err).toBe(null)
-    expect(result).toBe(42)
+    expect(result).toBe("42")
   })
 
   test("executeScript - shall pass with short notation and arguments", async () => {

--- a/dev-test/metadata.test.js
+++ b/dev-test/metadata.test.js
@@ -35,7 +35,7 @@ describe("metadata examples", () => {
     const answer = 42
     const args = [{answer}]
     const [result] = await shallResolve(executeScript({code, args}))
-    expect(result).toBe(answer)
+    expect(result).toBe(String(answer))
   })
 
   test("simple array - [String]", async () => {
@@ -65,7 +65,7 @@ describe("metadata examples", () => {
     const args = [[value], index]
 
     const [result, err] = await executeScript({code, args})
-    expect(result).toBe(value[index])
+    expect(result).toBe(String(value[index]))
     expect(err).toBe(null)
   })
 })

--- a/dev-test/usage.test.js
+++ b/dev-test/usage.test.js
@@ -112,7 +112,7 @@ describe("jest methods", () => {
         `,
       })
     )
-    expect(result).toBe(42)
+    expect(result).toBe(String(42))
     expect(err).toBe(null)
   })
 

--- a/dev-test/utilities.test.js
+++ b/dev-test/utilities.test.js
@@ -41,18 +41,18 @@ describe("block height offset", () => {
 
   it("should return zero offset", async () => {
     const [zeroOffset] = await executeScript("get-block-offset")
-    expect(zeroOffset).toBe(0)
+    expect(zeroOffset).toBe("0")
   })
 
   it("should update offset", async () => {
     const manager = await getServiceAddress()
     const [zeroOffset] = await executeScript("get-block-offset")
-    expect(zeroOffset).toBe(0)
+    expect(zeroOffset).toBe("0")
 
     const offset = 42
     await shallPass(sendTransaction("set-block-offset", [manager], [offset]))
     const [newOffset] = await executeScript("get-block-offset")
-    expect(newOffset).toBe(offset)
+    expect(newOffset).toBe(String(offset))
   })
 
   it("should read offset with utility method", async () => {
@@ -63,7 +63,7 @@ describe("block height offset", () => {
 
     const [offSet] = await getBlockOffset({addressMap})
 
-    expect(offSet).toBe(0)
+    expect(offSet).toBe("0")
   })
 
   it("should update offset with utility method", async () => {
@@ -74,7 +74,7 @@ describe("block height offset", () => {
 
     const [oldOffset] = await getBlockOffset({addressMap})
 
-    expect(oldOffset).toBe(0)
+    expect(oldOffset).toBe("0")
 
     const offset = 42
 
@@ -83,7 +83,7 @@ describe("block height offset", () => {
 
     const [newOffset] = await getBlockOffset({addressMap})
 
-    expect(newOffset).toBe(offset)
+    expect(newOffset).toBe(String(offset))
   })
 })
 
@@ -102,18 +102,18 @@ describe("block height offset utilities", () => {
 
   it("should return 0 for initial block offset", async () => {
     const [initialOffset] = await shallResolve(manager.getBlockOffset())
-    expect(initialOffset).toBe(0)
+    expect(initialOffset).toBe("0")
   })
 
   it("should update block offset", async () => {
     const [offset] = await shallResolve(manager.getBlockOffset())
-    expect(offset).toBe(0)
+    expect(offset).toBe("0")
 
     const blockOffset = 42
     await shallPass(manager.setBlockOffset(blockOffset))
 
     const [newOffset] = await shallResolve(manager.getBlockOffset())
-    expect(newOffset).toBe(blockOffset)
+    expect(newOffset).toBe(String(blockOffset))
   })
 })
 
@@ -145,7 +145,7 @@ describe("timestamp offset", () => {
       sendTransaction("set-timestamp-offset", [manager], [offset])
     )
     const [newOffset] = await executeScript("get-timestamp-offset")
-    expect(newOffset).toBe("42.00000000")
+    expect(newOffset).toBe(offset.toFixed(8))
   })
 
   it("should read offset with utility method", async () => {
@@ -156,7 +156,7 @@ describe("timestamp offset", () => {
 
     const [offSet] = await getTimestampOffset({addressMap})
 
-    expect(offSet).toBe(0)
+    expect(offSet).toBe("0.00000000")
   })
 
   it("should update offset with utility method", async () => {
@@ -167,7 +167,7 @@ describe("timestamp offset", () => {
 
     const [oldOffset] = await getTimestampOffset({addressMap})
 
-    expect(oldOffset).toBe(0)
+    expect(oldOffset).toBe("0.00000000")
 
     const offset = 42
 
@@ -176,7 +176,7 @@ describe("timestamp offset", () => {
 
     const [newOffset] = await getTimestampOffset({addressMap})
 
-    expect(newOffset).toBe(offset)
+    expect(newOffset).toBe(offset.toFixed(8))
   })
 })
 
@@ -193,20 +193,20 @@ describe("timestamp offset utilities", () => {
     return emulator.stop()
   })
 
-  it("should return 0 for initial block offset", async () => {
+  it("should return 0 for initial timestamp offset", async () => {
     const [initialOffset] = await shallResolve(manager.getTimestampOffset())
-    expect(initialOffset).toBe(0)
+    expect(initialOffset).toBe("0.00000000")
   })
 
-  it("should update block offset", async () => {
+  it("should update timestamp offset", async () => {
     const [offset] = await shallResolve(manager.getTimestampOffset())
-    expect(offset).toBe(0)
+    expect(offset).toBe("0.00000000")
 
     const blockOffset = 42
     await shallPass(manager.setTimestampOffset(blockOffset))
 
     const [newOffset] = await shallResolve(manager.getTimestampOffset())
-    expect(newOffset).toBe(blockOffset)
+    expect(newOffset).toBe(blockOffset.toFixed(8))
   })
 })
 
@@ -225,7 +225,7 @@ describe("dev tests", () => {
 
   it("should return proper offset", async () => {
     const [zeroOffset] = await executeScript("get-block-offset")
-    expect(zeroOffset).toBe(0)
+    expect(zeroOffset).toBe("0")
   })
 
   it("should return proper offset, when changed", async () => {
@@ -233,7 +233,7 @@ describe("dev tests", () => {
     const manager = await getServiceAddress()
     await shallPass(sendTransaction("set-block-offset", [manager], [offset]))
     const [newOffset] = await executeScript("get-block-offset")
-    expect(newOffset).toBe(offset)
+    expect(newOffset).toBe(String(offset))
   })
 
   it("should return proper addresses", async () => {

--- a/docs/send-transactions.md
+++ b/docs/send-transactions.md
@@ -17,13 +17,13 @@ Provides explicit control over how you pass values.
 
 `props` object accepts following fields:
 
-| Name         | Type                            | Optional | Description                                                                                          |
-| ------------ | ------------------------------- | -------- | ---------------------------------------------------------------------------------------------------- |
-| `code`       | string                          | ✅       | string representation of Cadence transaction                                                         |
-| `name`       | string                          | ✅       | name of the file in `transaction` folder to use (sans `.cdc` extension)                              |
-| `args`       | [Any]                           | ✅       | an array of arguments to pass to transaction. Optional if transaction does not expect any arguments. |
-| `signers`    | [Address]                       | ✅       | an array of [Address](#Address) representing transaction autorizers                                  |
-| `addressMap` | [AddressMap](api.md#addressmap) | ✅       | name/address map to use as lookup table for addresses in import statements                           |
+| Name         | Type                                                                                         | Optional | Description                                                                                                                                        |
+| ------------ | -------------------------------------------------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `code`       | string                                                                                       | ✅       | string representation of Cadence transaction                                                                                                       |
+| `name`       | string                                                                                       | ✅       | name of the file in `transaction` folder to use (sans `.cdc` extension)                                                                            |
+| `args`       | [Any]                                                                                        | ✅       | an array of arguments to pass to transaction. Optional if transaction does not expect any arguments.                                               |
+| `signers`    | [[Address](https://docs.onflow.org/fcl/reference/api/#address) or [SignerInfo](#signerinfo)] | ✅       | an array of [Address](https://docs.onflow.org/fcl/reference/api/#address) or [SignerInfo](#signerinfo) objects representing transaction autorizers |
+| `addressMap` | [AddressMap](api.md#addressmap)                                                              | ✅       | name/address map to use as lookup table for addresses in import statements                                                                         |
 
 > ⚠️ **Required:** Either `code` or `name` field shall be specified. Method will throw an error if both of them are empty.
 > If `name` field provided, framework will source code from file and override value passed via `code` field.
@@ -83,7 +83,7 @@ Cadence files.
 | --------- | --------- | -------- | ---------------------------------------------------------------------------------------------------- |
 | `name`    | string    | ✅       | name of the file in `transaction` folder to use (sans `.cdc` extension)                              |
 | `args`    | [Any]     | ✅       | an array of arguments to pass to transaction. Optional if transaction does not expect any arguments. |
-| `signers` | [Address] | ✅       | an array of [Address](#Address) representing transaction autorizers                                  |
+| `signers` | [Address] | ✅       | an array of [Address](#ddress) representing transaction autorizers                                   |
 
 #### Usage
 
@@ -108,3 +108,14 @@ const main = async () => {
 
 main()
 ```
+
+## Objects, structs, enums
+
+### SignerInfo
+
+| Key             | Required | Value Type                                                    | Description                                                                                                                                                                                        |
+| --------------- | -------- | ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `addr`          | Yes      | [Address](https://docs.onflow.org/fcl/reference/api/#address) | The address of the signer's account                                                                                                                                                                |
+| `hashAlgorithm` | No       | string                                                        | Hashing algorithm to use for the signature (either `"p256"` or `"secp256k1"`, default: `"p256"`)                                                                                                   |
+| `privateKey`    | No       | string                                                        | Private key to use to generate the signature (default: service account private key - this is the default PK for all accounts generated by Flow JS Testing Library, see: [accounts](./accounts.md)) |
+| `keyId`         | No       | number                                                        | The index of the desired key to use from the signer's account (default: `0`)                                                                                                                       |

--- a/examples/09-send-transaction.test.js
+++ b/examples/09-send-transaction.test.js
@@ -1,3 +1,4 @@
+import {config} from "@onflow/fcl"
 import path from "path"
 import {init, emulator, getAccountAddress, sendTransaction} from "../src"
 
@@ -24,7 +25,16 @@ test("send transaction", async () => {
       }
     }
   `
-  const signers = [Alice, Bob]
+
+  const signers = [
+    {
+      addr: Alice,
+      keyId: 0,
+      privateKey: await config().get("PRIVATE_KEY"),
+      hashAlgorithm: "p256",
+    },
+    Bob,
+  ]
   const args = ["Hello from Cadence"]
 
   // There are several ways to call "sendTransaction"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@onflow/flow-js-testing",
-  "version": "0.3.0-alpha.11",
+  "version": "0.3.0-alpha.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@onflow/flow-js-testing",
-      "version": "0.3.0-alpha.11",
+      "version": "0.3.0-alpha.12",
       "license": "Apache-2.0",
       "dependencies": {
         "@onflow/config": "^1.0.3-alpha.0",
@@ -8046,6 +8046,7 @@
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
       "<rootDir>/node_modules/"
     ],
     "testMatch": [
-      "**/(test|examples)/?(*.)+(spec|test).[jt]s?(x)"
+      "**/(test|examples|dev-test)/?(*.)+(spec|test).[jt]s?(x)"
     ]
   },
   "dependencies": {

--- a/src/interaction.js
+++ b/src/interaction.js
@@ -133,7 +133,7 @@ export const sendTransaction = async (...props) => {
 
     // use signers if specified
     if (signers) {
-      const auths = signers.map(address => authorization(address))
+      const auths = signers.map(signer => authorization(signer))
       ix.push(fcl.authorizations(auths))
     } else {
       // and only service account if no signers


### PR DESCRIPTION
Closes #154 

## Description

 - Allows signers to be provided as either an address (like before) or an object including any of the following properties: addr, privateKey, hashAlgorithm, keyId
 - Fixes dev-tests (were not being used by jest config previously)
 - Adds new dev-tests for signers provided as object
 - Adds documentation to sendTransaction

---

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-js-testing/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
