### PR TITLE
Add shallPass/shallResolve helpers to examples

### DIFF
--- a/examples/02-deploy-contract-by-name.test.js
+++ b/examples/02-deploy-contract-by-name.test.js
@@ -1,5 +1,12 @@
 import path from "path"
-import {init, emulator, deployContractByName, executeScript} from "../src"
+import {
+  init,
+  emulator,
+  deployContractByName,
+  executeScript,
+  shallResolve,
+  shallPass,
+} from "../src"
 
 beforeEach(async () => {
   // Init framework
@@ -12,34 +19,40 @@ beforeEach(async () => {
 
 test("deploy contract by name", async () => {
   // Deploy contract Greeting with single argument
-  await deployContractByName({
-    name: "Greeting",
-    args: ["Hello from Emulator"],
-  })
+  await shallPass(
+    deployContractByName({
+      name: "Greeting",
+      args: ["Hello from Emulator"],
+    })
+  )
 
   // Read contract field via script
-  const [greetingMessage] = await executeScript({
-    code: `
+  const [greetingMessage] = await shallResolve(
+    executeScript({
+      code: `
       import Greeting from 0x1
       
       pub fun main(): String{
         return Greeting.message
       } 
   `,
-  })
+    })
+  )
   expect(greetingMessage).toBe("Hello from Emulator")
 
   // Deploy contract Hello with no arguments
   await deployContractByName({name: "Hello"})
-  const [helloMessage] = await executeScript({
-    code: `
+  const [helloMessage] = await shallResolve(
+    executeScript({
+      code: `
       import Hello from 0x01
       
       pub fun main():String{
         return Hello.message
       }
     `,
-  })
+    })
+  )
   expect(helloMessage).toBe("Hi!")
 })
 

--- a/examples/03-deploy-contract.test.js
+++ b/examples/03-deploy-contract.test.js
@@ -5,6 +5,8 @@ import {
   getAccountAddress,
   deployContract,
   executeScript,
+  shallResolve,
+  shallPass,
 } from "../src"
 
 beforeEach(async () => {
@@ -29,16 +31,18 @@ test("deploy contract", async () => {
     `
   const args = [1337]
 
-  await deployContract({to, name, code, args})
+  await shallPass(deployContract({to, name, code, args}))
 
-  const [balance] = await executeScript({
-    code: `
+  const [balance] = await shallResolve(
+    executeScript({
+      code: `
       import Wallet from 0x01
       pub fun main(): UInt{
         return Wallet.balance
       }
     `,
-  })
+    })
+  )
   expect(balance).toBe("1337")
 })
 

--- a/examples/06-flow-management.test.js
+++ b/examples/06-flow-management.test.js
@@ -5,6 +5,7 @@ import {
   getAccountAddress,
   getFlowBalance,
   mintFlow,
+  shallResolve,
 } from "../src"
 
 beforeEach(async () => {
@@ -19,14 +20,14 @@ test("flow management", async () => {
   const Alice = await getAccountAddress("Alice")
 
   // Get initial balance
-  const [initialBalance] = await getFlowBalance(Alice)
+  const [initialBalance] = await shallResolve(getFlowBalance(Alice))
   expect(initialBalance).toBe("0.00100000")
 
   // Add 1.0 FLOW tokens to Alice account
   await mintFlow(Alice, "1.0")
 
   // Check updated balance
-  const [updatedBalance] = await getFlowBalance(Alice)
+  const [updatedBalance] = await shallResolve(getFlowBalance(Alice))
   const expectedBalance = parseFloat(initialBalance) + 1.0
   expect(parseFloat(updatedBalance)).toBe(expectedBalance)
 

--- a/examples/07-block-offset.test.js
+++ b/examples/07-block-offset.test.js
@@ -6,6 +6,7 @@ import {
   setBlockOffset,
   builtInMethods,
   executeScript,
+  shallResolve,
 } from "../src"
 
 beforeEach(async () => {
@@ -16,7 +17,7 @@ beforeEach(async () => {
 })
 
 test("block offset", async () => {
-  const [initialBlockOffset] = await getBlockOffset()
+  const [initialBlockOffset] = await shallResolve(getBlockOffset())
   expect(initialBlockOffset).toBe("0")
 
   // "getCurrentBlock().height" in your Cadence code will be replaced by Manager to a mocked value
@@ -27,7 +28,7 @@ test("block offset", async () => {
   `
 
   // We can check that non-transformed code still works just fine
-  const [normalResult] = await executeScript({code})
+  const [normalResult] = await shallResolve(executeScript({code}))
   expect(normalResult).toBe("1")
 
   // Offset current block height by 42
@@ -39,7 +40,9 @@ test("block offset", async () => {
   // "transformers" field expects array of functions to operate update the code.
   // We will pass single operator "builtInMethods" provided by the framework to alter how getCurrentBlock().height is calculated
   const transformers = [builtInMethods]
-  const [transformedResult] = await executeScript({code, transformers})
+  const [transformedResult] = await shallResolve(
+    executeScript({code, transformers})
+  )
   expect(transformedResult).toBe("44")
 })
 

--- a/examples/08-execute-script.test.js
+++ b/examples/08-execute-script.test.js
@@ -1,5 +1,5 @@
 import path from "path"
-import {init, emulator, executeScript} from "../src"
+import {init, emulator, executeScript, shallResolve} from "../src"
 
 beforeEach(async () => {
   const basePath = path.resolve(__dirname, "./cadence")
@@ -39,8 +39,8 @@ test("execute script", async () => {
   ]
   const name = "log-args"
 
-  const [fromCode] = await executeScript({code, args})
-  const [fromFile] = await executeScript({name, args})
+  const [fromCode] = await shallResolve(executeScript({code, args}))
+  const [fromFile] = await shallResolve(executeScript({name, args}))
   expect(fromCode).toBe(fromFile)
   expect(fromCode).toBe("42")
 

--- a/examples/09-send-transaction.test.js
+++ b/examples/09-send-transaction.test.js
@@ -1,5 +1,3 @@
-/* eslint-disable jest/expect-expect */
-/* eslint-disable no-unused-vars */
 import path from "path"
 import {
   init,
@@ -45,6 +43,10 @@ test("send transaction", async () => {
 
   // 3. Providing name of the file in short form (name, signers, args)
   const [txShortResult] = await shallPass(sendTransaction(name, signers, args))
+
+  // Check that all transaction results are the same
+  expect(txFileResult).toEqual(txInlineResult)
+  expect(txShortResult).toEqual(txInlineResult)
 })
 
 afterEach(async () => {

--- a/examples/09-send-transaction.test.js
+++ b/examples/09-send-transaction.test.js
@@ -1,6 +1,14 @@
+/* eslint-disable jest/expect-expect */
+/* eslint-disable no-unused-vars */
 import {config} from "@onflow/fcl"
 import path from "path"
-import {init, emulator, getAccountAddress, sendTransaction} from "../src"
+import {
+  init,
+  emulator,
+  getAccountAddress,
+  sendTransaction,
+  shallPass,
+} from "../src"
 
 beforeEach(async () => {
   const basePath = path.resolve(__dirname, "./cadence")
@@ -39,19 +47,14 @@ test("send transaction", async () => {
 
   // There are several ways to call "sendTransaction"
   // 1. Providing "code" field for Cadence template
-  const [txInlineResult] = await sendTransaction({code, signers, args})
+  const [txInlineResult] = await shallPass(
+    sendTransaction({code, signers, args})
+  )
   // 2. Providing "name" field to read Cadence template from file in "./transaction" folder
-  const [txFileResult] = await sendTransaction({name, signers, args})
-
-  expect(txInlineResult).toBeTruthy()
-  expect(txFileResult).toBeTruthy()
-  expect(txInlineResult.statusCode).toBe(0)
-  expect(txFileResult.statusCode).toBe(0)
+  const [txFileResult] = await shallPass(sendTransaction({name, signers, args}))
 
   // 3. Providing name of the file in short form (name, signers, args)
-  const [txShortResult] = await sendTransaction(name, signers, args)
-  expect(txShortResult).toBeTruthy()
-  expect(txShortResult.statusCode).toBe(0)
+  const [txShortResult] = await shallPass(sendTransaction(name, signers, args))
 })
 
 afterEach(async () => {

--- a/examples/10-templates.test.js
+++ b/examples/10-templates.test.js
@@ -20,23 +20,24 @@ test("templates", async () => {
     Profile: "0xf8d6e0586b0a20c7",
   }
 
-  const withPath = await getTemplate(
+  const withPath = getTemplate(
     path.resolve(__dirname, "./cadence/scripts/replace-address.cdc"),
     addressMap
   )
-  expect(withPath).toBeTruthy()
 
   const contractTemplate = await getContractCode({name: "Greeting", addressMap})
-  expect(contractTemplate).toBeTruthy()
 
   const transactionTemplate = await getTransactionCode({
     name: "log-signers",
     addressMap,
   })
-  expect(transactionTemplate).toBeTruthy()
 
   const scriptTemplate = await getScriptCode({name: "log-args", addressMap})
-  expect(scriptTemplate).toBeTruthy()
+
+  expect(withPath).toBeDefined()
+  expect(contractTemplate).toBeDefined()
+  expect(transactionTemplate).toBeDefined()
+  expect(scriptTemplate).toBeDefined()
 })
 
 afterEach(async () => {

--- a/examples/100-pass-array-of-dictionaries.test.js
+++ b/examples/100-pass-array-of-dictionaries.test.js
@@ -1,5 +1,5 @@
 import path from "path"
-import {init, emulator, executeScript} from "../src"
+import {init, emulator, executeScript, shallResolve} from "../src"
 
 beforeEach(async () => {
   const basePath = path.resolve(__dirname, "./cadence")
@@ -24,9 +24,8 @@ test("pass array of dictionaries", async () => {
     "name",
   ]
 
-  const result = await executeScript({code, args})
-  expect(result[0]).toBe("Giovanni Giorgio")
-  expect(result[1]).toBeNull()
+  const [result] = await shallResolve(executeScript({code, args}))
+  expect(result).toBe("Giovanni Giorgio")
 })
 
 afterEach(async () => {

--- a/examples/101-pass-int-dictionary.test.js
+++ b/examples/101-pass-int-dictionary.test.js
@@ -1,5 +1,5 @@
 import path from "path"
-import {init, emulator, executeScript} from "../src"
+import {init, emulator, executeScript, shallResolve} from "../src"
 
 beforeEach(async () => {
   const basePath = path.resolve(__dirname, "./cadence")
@@ -17,7 +17,7 @@ test("pass int dictionary", async () => {
 
   const args = [{0: 1, 1: 42}, 1]
 
-  const [result] = await executeScript({code, args})
+  const [result] = await shallResolve(executeScript({code, args}))
   expect(result).toBe("42")
 })
 

--- a/examples/102-pass-string-to-int-dictionary.test.js
+++ b/examples/102-pass-string-to-int-dictionary.test.js
@@ -1,5 +1,5 @@
 import path from "path"
-import {init, emulator, executeScript} from "../src"
+import {init, emulator, executeScript, shallResolve} from "../src"
 
 beforeEach(async () => {
   const basePath = path.resolve(__dirname, "./cadence")
@@ -17,7 +17,7 @@ test("pass string to int dictionary", async () => {
 
   const args = [{cadence: 0, test: 1337}, "cadence"]
 
-  const [result] = await executeScript({code, args})
+  const [result] = await shallResolve(executeScript({code, args}))
   expect(result).toBe("0")
 })
 


### PR DESCRIPTION
Closes #159 

## Description

Adds shallResolve/shallPass helpers to examples as this is an important Flow JS Testing feature to showcase and should be part of the examples.

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-js-testing/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
