### PR TITLE
Fix default compute limit deprecation warning

### DIFF
--- a/.changeset/bright-comics-fold.md
+++ b/.changeset/bright-comics-fold.md
@@ -1,0 +1,5 @@
+---
+"@onflow/flow-js-testing": patch
+---
+
+Fix the warning about deprecated default compute limit for transactions

--- a/dev-test/config.test.js
+++ b/dev-test/config.test.js
@@ -1,0 +1,9 @@
+import {getConfigValue} from "../src"
+
+describe("configuration tests", () => {
+  test("defaultComputeLimit - set default compute limit", async () => {
+    const limit = await getConfigValue("fcl.limit")
+
+    expect(limit).toBe(999)
+  })
+})

--- a/src/config.js
+++ b/src/config.js
@@ -20,6 +20,21 @@ import {flowConfig} from "@onflow/fcl-config"
 import {config} from "@onflow/fcl"
 
 /**
+ * The default compute limit for transactions.
+ */
+export const DEFAULT_COMPUTE_LIMIT = 999
+
+/**
+ * Set the default compute limit for transactions.
+ *
+ * Previously, providing a compute limit for transactions was optional and
+ * a fallback existed (DEFAULT_COMPUTE_LIMIT=10). Compute limits may still
+ * be applied explicitly in a transaction.
+ * @link https://github.com/onflow/fcl-js/blob/master/packages/sdk/TRANSITIONS.md#0009-deprecate-default-compute-limit
+ */
+config().put("fcl.limit", DEFAULT_COMPUTE_LIMIT)
+
+/**
  * Get value from provided scope and path.
  * @param scope - scope value.
  * @param path - value path in config (flow.json) file.

--- a/src/interaction.js
+++ b/src/interaction.js
@@ -18,6 +18,7 @@
 
 import * as fcl from "@onflow/fcl"
 import {resolveArguments} from "@onflow/flow-cadut"
+import {DEFAULT_COMPUTE_LIMIT} from "./config"
 import {authorization} from "./crypto"
 import emulator from "./emulator/emulator"
 import {getTransactionCode, getScriptCode, defaultsByName} from "./file"
@@ -25,8 +26,6 @@ import {resolveImports, replaceImportAddresses} from "./imports"
 import {getServiceAddress} from "./utils"
 import {applyTransformers, builtInMethods} from "./transformers"
 import {isObject} from "./utils"
-
-const DEFAULT_LIMIT = 999
 
 export const extractParameters = ixType => {
   return async params => {
@@ -67,7 +66,7 @@ export const extractParameters = ixType => {
     }
 
     // Check that limit is always set
-    ixLimit = ixLimit || DEFAULT_LIMIT
+    ixLimit = ixLimit || DEFAULT_COMPUTE_LIMIT
 
     if (ixName) {
       const getIxTemplate =


### PR DESCRIPTION
## Description

Fixes the warning about the deprecated default compute limit for transactions.

```
FCL/SDK Deprecation Notice
==========================
    
The built-in default compute limit (DEFAULT_COMPUTE_LIMIT=10) is
deprecated and will cease to work in future releases of FCL/SDK.
```

Previously, providing a compute limit for transactions was optional, and a fallback existed (DEFAULT_COMPUTE_LIMIT=10). Compute limits may still be applied explicitly in a transaction.

`flow-js-testing` already has a way to set the limit per transaction, but the default value is also required now.

The value is set to 999 as it was in interactions, and the value is now imported to interactions from the config file just to have it in one location.

Also, a configuration test is added.

More information about the deprecation https://github.com/onflow/fcl-js/blob/master/packages/sdk/TRANSITIONS.md#0009-deprecate-default-compute-limit

---

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-js-testing/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation – **No relevant parts in documentation**
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels – **No permissions to add labels**
