### PR TITLE
resolve outdated import of flow-cadut/generator

### DIFF
--- a/src/cli/commands/init.js
+++ b/src/cli/commands/init.js
@@ -17,7 +17,7 @@
  */
 
 import {execSync} from "child_process"
-import {writeFile} from "@onflow/flow-cadut/generator"
+import {writeFile} from "@onflow/flow-cadut-generator"
 
 import babelConfig from "../templates/babel-config"
 import jestConfig from "../templates/jest-config"

--- a/src/cli/commands/make.js
+++ b/src/cli/commands/make.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import {writeFile} from "@onflow/flow-cadut/generator"
+import {writeFile} from "@onflow/flow-cadut-generator"
 import testTemplate from "../templates/test"
 
 const hashedTimestamp = () => {


### PR DESCRIPTION
Closes #???

## Description

<!--
@onflow/flow-cadut/generator is now changed to @onflow/flow-cadut-generator
-->

---

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-js-testing/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
