### PR TITLE
Use proper generator package

### DIFF
--- a/.changeset/happy-gifts-bake.md
+++ b/.changeset/happy-gifts-bake.md
@@ -1,0 +1,5 @@
+---
+"@onflow/flow-js-testing": patch
+---
+
+Fix imports for flow-cadut generator

--- a/dev-test/utilities.test.js
+++ b/dev-test/utilities.test.js
@@ -20,7 +20,6 @@ import {
   builtInMethods,
   playgroundImport,
 } from "../src/transformers"
-import {getManagerAddress} from "../src/manager"
 import * as manager from "../src/manager"
 import {query} from "@onflow/fcl"
 
@@ -30,8 +29,8 @@ jest.setTimeout(10000)
 describe("block height offset", () => {
   // Instantiate emulator and path to Cadence files
   beforeEach(async () => {
-    const base = path.resolve(__dirname, "../cadence")
-    await init({base})
+    const basePath = path.resolve(__dirname, "../cadence")
+    await init(basePath)
     return emulator.start()
   })
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
       "<rootDir>/node_modules/"
     ],
     "testMatch": [
-      "**/(test|examples|dev-test)/?(*.)+(spec|test).[jt]s?(x)"
+      "**/(test)/?(*.)+(spec|test).[jt]s?(x)"
     ]
   },
   "dependencies": {

--- a/src/cli/commands/init.js
+++ b/src/cli/commands/init.js
@@ -17,7 +17,7 @@
  */
 
 import {execSync} from "child_process"
-import {writeFile} from "@onflow/flow-cadut/generator"
+import {writeFile} from "@onflow/flow-cadut-generator"
 
 import babelConfig from "../templates/babel-config"
 import jestConfig from "../templates/jest-config"

--- a/src/cli/commands/make.js
+++ b/src/cli/commands/make.js
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import {writeFile} from "@onflow/flow-cadut/generator"
+import {writeFile} from "@onflow/flow-cadut-generator"
 import testTemplate from "../templates/test"
 
 const hashedTimestamp = () => {


### PR DESCRIPTION
Closes #180 

## Description
CLI commands were using old `flow-cadut` generator leading to error during call.
I've fixed imports to proper library and confirmed locally that it works as intended

For contributor use:
- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-js-testing/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
