### PR TITLE
Pass interaction props through logger

### DIFF
--- a/src/interaction.js
+++ b/src/interaction.js
@@ -123,7 +123,7 @@ export const extractParameters = ixType => {
 export const sendTransaction = async (...props) => {
   let result = null,
     err = null
-  const logs = await captureLogs(async () => {
+  const logs = await captureLogs(async props => {
     try {
       const extractor = extractParameters("tx")
       const {code, args, signers, limit} = await extractor(props)
@@ -157,7 +157,7 @@ export const sendTransaction = async (...props) => {
     } catch (e) {
       err = e
     }
-  })
+  }, props)
   return [result, err, logs]
 }
 
@@ -172,7 +172,7 @@ export const sendTransaction = async (...props) => {
 export const executeScript = async (...props) => {
   let result = null,
     err = null
-  const logs = await captureLogs(async () => {
+  const logs = await captureLogs(async props => {
     try {
       const extractor = extractParameters("script")
       const {code, args, limit} = await extractor(props)
@@ -188,15 +188,15 @@ export const executeScript = async (...props) => {
     } catch (e) {
       err = e
     }
-  })
+  }, props)
   return [result, err, logs]
 }
 
-export const captureLogs = async callback => {
+export const captureLogs = async (callback, props) => {
   const logs = []
   const listener = msg => logs.push(msg)
   emulator.logger.on("log", listener)
-  await callback()
+  await callback(props)
   emulator.logger.removeListener("log", listener)
   return logs
 }


### PR DESCRIPTION
Closes https://github.com/onflow/flow-js-testing/issues/182

## Description

Fixes the underlying issue behind `getAccountAddress` not working on `0.3.0-alpha.15` where the interaction logging was introduced.

As stated in https://github.com/onflow/flow-js-testing/issues/182#issuecomment-1248274199, the issue exists because of how Microbundle handles async function arguments. This issue has likely not been noticed as the tests in the example folder use the source files instead of the bundled ones.

The issue is fixed by passing the interaction props through the logger back to the transactions and scripts.

---

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-js-testing/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation (no relevant documentation)
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
