### PR TITLE
Fix passing props when executing script

### DIFF
--- a/.changeset/brown-bugs-fry.md
+++ b/.changeset/brown-bugs-fry.md
@@ -1,0 +1,5 @@
+---
+"@onflow/flow-js-testing": patch
+---
+
+Add explicit scoping to arguments for scripts in nested await functions to hint microbunde into doing the right thing

--- a/src/interaction.js
+++ b/src/interaction.js
@@ -172,12 +172,14 @@ export const sendTransaction = async (...props) => {
  * @returns {Promise<*>}
  */
 export const executeScript = async (...props) => {
+  // This is here to fix an issue with microbundler confusing argument scopes
+  let _props = props
   let result = null,
     err = null
   const logs = await captureLogs(async () => {
     try {
       const extractor = extractParameters("script")
-      const {code, args, limit} = await extractor(props)
+      const {code, args, limit} = await extractor(_props)
 
       const ix = [fcl.script(code), fcl.limit(limit)]
       // add arguments if any


### PR DESCRIPTION
## Description

https://github.com/onflow/flow-js-testing/pull/186 Fixes the scoping issue of transaction props, but this needs to be done for executing the scripts as well. Executing scripts using the bundle won't work without the fix, so would be great to have a new release once this gets merged.

These bundle-related issues can't be seen by running the test suite, as the tests use the source code.

---

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-js-testing/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation - **no relevant documentation**
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
