### PR TITLE
Fix emulator start not return true on success

### DIFF
--- a/src/emulator/emulator.js
+++ b/src/emulator/emulator.js
@@ -126,7 +126,7 @@ More info: https://github.com/onflow/flow-js-testing/blob/master/TRANSITIONS.md#
         this.initialized = success
         this.logger.removeListener(LOGGER_LEVELS.ERROR, listener)
         clearInterval(internalId)
-        if (success) resolve()
+        if (success) resolve(true)
         else reject()
       }
 


### PR DESCRIPTION
Closes #197.

## Description

Fix `emulator.start` not returning `true` when it is started successfully per documentation.

---

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-js-testing/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
