### PR TITLE
Fix emulator rest url (#196)

### DIFF
--- a/src/emulator/emulator.js
+++ b/src/emulator/emulator.js
@@ -93,7 +93,7 @@ More info: https://github.com/onflow/flow-js-testing/blob/master/TRANSITIONS.md#
     const {flags = "", logging = false} = options
 
     // config access node
-    config().put("accessNode.api", `http://localhost:${this.restPort}`)
+    config().put("accessNode.api", `http://127.0.0.1:${this.restPort}`)
 
     this.logging = logging
     this.process = spawn("flow", [


### PR DESCRIPTION
Closes #196

## Description

Not sure why localhost is not working, but seems like 127.0.0.1 solved the issue. 

---

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-js-testing/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
