### PR TITLE
OSS Support Grant: Milestone 2 - Add methods to inspect account storage

### DIFF
--- a/.changeset/modern-guests-roll.md
+++ b/.changeset/modern-guests-roll.md
@@ -1,0 +1,7 @@
+---
+"@onflow/flow-js-testing": minor
+---
+
+- Storage inspection API implemented as set of utility methods
+- Additional Jest helpers implemented
+- Related documentation added

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,6 +12,8 @@ module.exports = {
     ecmaVersion: 12,
     sourceType: "module",
   },
-  rules: {},
+  rules: {
+    "jest/expect-expect": "off",
+  },
   plugins: ["jest"],
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -935,7 +935,7 @@ describe("interactions - sendTransaction", () => {
     )
 
     // Catch only specific panic message
-    let [txResult, error] = await shallRevert(
+    let [txResult2, error2] = await shallRevert(
       sendTransaction({
         code,
         signers,
@@ -1409,6 +1409,210 @@ const main = async () => {
   })
 
   console.log({scriptTemplate})
+  await emulator.stop()
+}
+
+main()
+```
+
+## Storage Inspection
+
+### getPaths
+
+Retrieves information about the public, private, and storage paths for a given account.
+
+#### Arguments
+
+| Name                | Type      | Description                                                           |
+| ------------------- | --------- | --------------------------------------------------------------------- |
+| `address`           | `string`  | The address or name of the account to retrieve the paths from.        |
+| `useSet` (optional) | `boolean` | Whether to return the paths as a Set or an array. Defaults to `true`. |
+
+#### Returns
+
+An object containing the following properties:
+
+| Name           | Type                             | Description                                                       |
+| -------------- | -------------------------------- | ----------------------------------------------------------------- |
+| `publicPaths`  | `Array<string>` or `Set<string>` | An array or Set of the public paths for the account, as strings.  |
+| `privatePaths` | `Array<string>` or `Set<string>` | An array or Set of the private paths for the account, as strings. |
+| `storagePaths` | `Array<string>` or `Set<string>` | An array or Set of the storage paths for the account, as strings. |
+
+> The `useSet` parameter determines whether the paths are returned as an array or Set. If `useSet` is `true`, the paths will be returned as a Set; otherwise, they will be returned as an array.
+
+#### Usage
+
+```js
+import path from "path"
+import {init, emulator} from "@onflow/flow-js-testing"
+import {getAccountAddress, getPaths} from "@onflow/flow-js-testing"
+
+const main = async () => {
+  const basePath = path.resolve(__dirname, "../cadence")
+
+  await init(basePath)
+  await emulator.start()
+
+  // Get storage stats
+  const Alice = await getAccountAddress("Alice")
+  const paths = await getPaths(Alice)
+  const {publicPaths, privatePaths, storagePaths} = paths
+
+  // Output result to console
+  console.log({Alice, paths})
+
+  await emulator.stop()
+}
+
+main()
+```
+
+### getPathsWithType
+
+Retrieves public, private, and storage paths for a given account with extra information available on them
+
+#### Arguments
+
+| Name      | Type     | Description                                                    |
+| --------- | -------- | -------------------------------------------------------------- |
+| `address` | `string` | The address or name of the account to retrieve the paths from. |
+
+#### Returns
+
+An object containing the following properties:
+
+| Name           | Type     | Description                                                                                |
+| -------------- | -------- | ------------------------------------------------------------------------------------------ |
+| `publicPaths`  | `Object` | An object containing the public paths for the account, as keys and their types as values.  |
+| `privatePaths` | `Object` | An object containing the private paths for the account, as keys and their types as values. |
+| `storagePaths` | `Object` | An object containing the storage paths for the account, as keys and their types as values. |
+
+> The types of the paths are not strictly defined and may vary depending on the actual types used in the account.
+
+#### Usage
+
+```js
+import path from "path"
+import {init, emulator} from "@onflow/flow-js-testing"
+import {getPathsWithType} from "@onflow/flow-js-testing"
+
+const main = async () => {
+  const basePath = path.resolve(__dirname, "../cadence")
+
+  await init(basePath)
+  await emulator.start()
+
+  const {publicPaths} = await getPathsWithType("Alice")
+  const refTokenBalance = publicPaths.flowTokenBalance
+
+  if (
+    refTokenBalance.restrictionsList.has(
+      "A.ee82856bf20e2aa6.FungibleToken.Balance"
+    )
+  ) {
+    console.log("Found specific restriction")
+  }
+
+  if (refTokenBalance.haveRestrictions("FungibleToken.Balance")) {
+    console.log("Found matching restriction")
+  }
+
+  await emulator.stop()
+}
+
+main()
+```
+
+### getStorageValue
+
+#### Arguments
+
+| Name      | Type     | Description                                                            |
+| --------- | -------- | ---------------------------------------------------------------------- |
+| `account` | `string` | The address or name of the account to retrieve the storage value from. |
+| `path`    | `string` | The path of the storage value to retrieve.                             |
+
+#### Returns
+
+| Type           | Description                                                                 |
+| -------------- | --------------------------------------------------------------------------- |
+| `Promise<any>` | The value of the storage at the given path, or `null` if no value is found. |
+
+#### Usage
+
+```js
+import path from "path"
+import {init, emulator} from "@onflow/flow-js-testing"
+import {sendTransaction, getStorageValue} from "@onflow/flow-js-testing"
+
+const main = async () => {
+  const basePath = path.resolve(__dirname, "../cadence")
+
+  await init(basePath)
+  await emulator.start()
+
+  // Inplant some value into account
+  await sendTransaction({
+    code: `
+        transaction{
+          prepare(signer: AuthAccount){
+            signer.save(42, to: /storage/answer)
+          }
+        }
+      `,
+    signers: [Alice],
+  })
+  const answer = await getStorageValue("Alice", "answer")
+  console.log({answer})
+
+  await emulator.stop()
+}
+
+main()
+```
+
+### getStorageStats
+
+Retrieves the storage statistics (used and capacity) for a given account.
+
+#### Arguments
+
+| Name                 | Type      | Description                                                                                      |
+| -------------------- | --------- | ------------------------------------------------------------------------------------------------ |
+| `address`            | `string`  | The address or name of the account to check for storage statistics.                              |
+| `convert` (optional) | `boolean` | Whether to convert the `used` and `capacity` values from strings to numbers. Defaults to `true`. |
+
+#### Returns
+
+A Promise that resolves to an object containing the following properties:
+
+| Name       | Type                 | Description                                          |
+| ---------- | -------------------- | ---------------------------------------------------- |
+| `used`     | `number` or `string` | The amount of storage used by the account, in bytes. |
+| `capacity` | `number` or `string` | The total storage capacity of the account, in bytes. |
+
+> If `convert` is `true`, the `used` and `capacity` values will be converted from strings to numbers before being returned.
+
+#### Usage
+
+```js
+import path from "path"
+import {init, emulator} from "@onflow/flow-js-testing"
+import {getAccountAddress, getStorageStats} from "@onflow/flow-js-testing"
+
+const main = async () => {
+  const basePath = path.resolve(__dirname, "../cadence")
+
+  await init(basePath)
+  await emulator.start()
+
+  // Get storage stats
+  const Alice = await getAccountAddress("Alice")
+  const {capacity, used} = await getStorageStats(Alice)
+
+  // Output result to console
+  console.log({Alice, capacity, used})
+
   await emulator.stop()
 }
 

--- a/docs/jest-helpers.md
+++ b/docs/jest-helpers.md
@@ -205,3 +205,75 @@ describe("interactions - sendTransaction", () => {
   })
 })
 ```
+
+## shallHavePath(account, path)
+
+Asserts that the given account has the given path enabled.
+
+#### Arguments
+
+| Name      | Type     | Description                                               |
+| --------- | -------- | --------------------------------------------------------- |
+| `account` | `string` | The address or name of the account to check for the path. |
+| `path`    | `string` | The path to check for.                                    |
+
+#### Returns
+
+| Type            | Description                                                                                   |
+| --------------- | --------------------------------------------------------------------------------------------- |
+| `Promise<void>` | A Promise that resolves when the assertion is complete, or rejects with an error if it fails. |
+
+#### Usage
+
+```javascript
+import path from "path"
+import {init, emulator, shallPass, executeScript} from "js-testing-framework"
+
+// We need to set timeout for a higher number, cause some interactions might need more time
+jest.setTimeout(10000)
+
+describe("interactions - sendTransaction", () => {
+  // Instantiate emulator and path to Cadence files
+  beforeEach(async () => {
+    const basePath = path.resolve(__dirname, "./cadence")
+    await init(basePath)
+    return emulator.start()
+  })
+
+  // Stop emulator, so it could be restarted
+  afterEach(async () => {
+    return emulator.stop()
+  })
+
+  describe("check path with Jest helper", () => {
+    test("pass account address", async () => {
+      const Alice = await getAccountAddress("Alice")
+      await shallHavePath(Alice, "/storage/flowTokenVault")
+    })
+
+    test("pass account name", async () => {
+      await shallHavePath("Alice", "/storage/flowTokenVault")
+    })
+  })
+})
+```
+
+## shallHaveStorageValue(account, params)
+
+Asserts that the given account has the expected storage value at the given path.
+
+#### Arguments
+
+| Name              | Type                                            | Description                                                                                            |
+| ----------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `account`         | `string`                                        | The address or name of the account to check for the storage value.                                     |
+| `params`          | `{pathName: string, key?: string, expect: any}` | An object containing the path name, optional key, and expected value of the storage at the given path. |
+| `params.pathName` | `string`                                        | The path of the storage value to retrieve.                                                             |
+| `params.key`      | `string` (optional)                             | The key of the value to retrieve from the storage at the given path, if applicable.                    |
+| `expect`          | `any`                                           | The expected value of the storage at the given path and key (if applicable).                           |
+
+#### Returns
+
+| Type            | Description                                                                                   |
+| --------------- | --------------------------------------------------------------------------------------------- |
+| `Promise<void>` | A Promise that resolves when the assertion is complete, or rejects with an error if it fails. |

--- a/src/file.js
+++ b/src/file.js
@@ -36,6 +36,12 @@ export const defaultsByName = {
   FungibleToken: "0xee82856bf20e2aa6",
   FlowFees: "0xe5a8b7f23e8b548f",
   FlowStorageFees: "0xf8d6e0586b0a20c7",
+
+  FUSD: "0xf8d6e0586b0a20c7",
+  NonFungibleToken: "0xf8d6e0586b0a20c7",
+  MetadataViews: "0xf8d6e0586b0a20c7",
+  NFTStorefront: "0xf8d6e0586b0a20c7",
+  NFTStorefrontV2: "0xf8d6e0586b0a20c7",
 }
 
 /**

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,0 +1,83 @@
+import {executeScript} from "./interaction"
+
+function reduce(arr) {
+  return arr.reduce(nameExtractor, new Set())
+}
+function nameExtractor(acc, pathStruct) {
+  acc.add(pathStruct.identifier)
+  return acc
+}
+export async function getPaths(address) {
+  const [result] = await executeScript({
+    code: `
+      pub struct PathInfo{
+        pub let public: [PublicPath]
+        pub let private: [PrivatePath]
+        pub let storage: [StoragePath]
+        
+        init(public: [PublicPath], private: [PrivatePath], storage: [StoragePath]){
+          self.public = public
+          self.private = private
+          self.storage = storage
+        }
+      }
+      pub fun main(address: Address): PathInfo{
+        let account = getAuthAccount(address)
+        let info = PathInfo(
+          public: account.publicPaths, 
+          private: account.privatePaths, 
+          storage: account.storagePaths
+        )
+        return info
+      }
+    `,
+    args: [address],
+  })
+
+  return {
+    publicPaths: reduce(result.public),
+    privatePaths: reduce(result.private),
+    storagePaths: reduce(result.storage),
+  }
+}
+
+export async function getStorageValue(account, path) {
+  let fixedPath = path.startsWith("/") ? path.slice(1) : path
+  let storagePath = `/storage/${fixedPath}`
+  const args = [account, storagePath]
+  const code = `
+    import MetadataViews from 0x1
+    
+    pub fun main(address: Address, path: StoragePath): AnyStruct{
+      let account = getAuthAccount(address)
+      
+      if let valueType = account.type(at: path) {
+        if(valueType.isSubtype(of: Type<@AnyResource>())){
+          let obj = account.borrow< auth &AnyResource >(from: path)!
+          let meta = obj as? &AnyResource{MetadataViews.ResolverCollection}
+        
+          if let idList = meta?.getIDs(){
+            if(idList.length > 0){
+              let res: {UInt64: AnyStruct} = {}
+            
+              for id in idList {
+                res[id] = meta!.borrowViewResolver(id: id).resolveView(Type<MetadataViews.Display>())!
+              }
+              return res
+            }
+          }
+          
+          let value = account.borrow< &AnyResource >(from: path)! as AnyStruct
+          return value  
+        }
+        
+        let value = account.borrow< &AnyStruct >(from: path)! as AnyStruct
+        return value  
+      }
+      
+      return nil
+    }
+  `
+  const [values, error] = await executeScript({code, args})
+  return [values, error]
+}

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,3 +1,21 @@
+/*
+ * Flow JS Testing
+ *
+ * Copyright 2020-2023 Dapper Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import {executeScript} from "./interaction"
 
 function reduce(arr) {

--- a/src/storage.js
+++ b/src/storage.js
@@ -16,16 +16,89 @@
  * limitations under the License.
  */
 
+import {getAccountAddress} from "./account"
 import {executeScript} from "./interaction"
+import {isAddress, parsePath} from "./utils"
 
-function reduce(arr) {
-  return arr.reduce(nameExtractor, new Set())
-}
-function nameExtractor(acc, pathStruct) {
+// Helpers
+function createSet(acc, pathStruct) {
   acc.add(pathStruct.identifier)
   return acc
 }
-export async function getPaths(address) {
+function reduceToSet(arr) {
+  return arr.reduce(createSet, new Set())
+}
+function reduceToUniqueArray(arr) {
+  const set = reduceToSet(arr)
+  return Array.from(set)
+}
+function reduceValues(arr, useSet) {
+  if (useSet) {
+    return reduceToSet(arr)
+  }
+
+  return reduceToUniqueArray(arr)
+}
+function formatReferences(paths) {
+  return Object.keys(paths).reduce((acc, path) => {
+    const {slot} = parsePath(path)
+    const value = paths[path].type.type
+
+    value.fullType = value.typeID
+    value.restrictionsList = new Set(
+      value.restrictions.map(item => {
+        return item.typeID
+      })
+    )
+
+    // Extra methods to query restrictions
+    value.haveRestrictions = function (query) {
+      for (const item of value.restrictionsList) {
+        if (item.includes(query)) {
+          return true
+        }
+      }
+      return false
+    }
+
+    acc[slot] = value
+
+    return acc
+  }, {})
+}
+function formatStorage(paths) {
+  return Object.keys(paths).reduce((acc, path) => {
+    const {slot} = parsePath(path)
+    acc[slot] = paths[path]
+    return acc
+  }, {})
+}
+function processValues(result) {
+  const publicPaths = formatReferences(result.publicPaths)
+  const privatePaths = formatReferences(result.privatePaths)
+  const storagePaths = formatStorage(result.storagePaths)
+
+  return {publicPaths, privatePaths, storagePaths}
+}
+
+/**
+ * Retrieves information about the public, private, and storage paths for a given account.
+ *
+ * @async
+ * @param {string} account - The address or the name of the account to retrieve path information for.
+ * @param {boolean} [useSet=true] - Whether to return array or Set
+ * @returns {Promise<{
+ *   publicPaths: string[] | Set<string>,
+ *   privatePaths: string[] | Set<string>,
+ *   storagePaths: string[] | Set<string>
+ * }>} An object containing arrays or Sets of the public, private, and storage paths for the account.
+ */
+export async function getPaths(account, useSet = true) {
+  let accountAddress = account
+  if (!isAddress(accountAddress)) {
+    accountAddress = await getAccountAddress(account)
+  }
+
   const [result] = await executeScript({
     code: `
       pub struct PathInfo{
@@ -49,20 +122,88 @@ export async function getPaths(address) {
         return info
       }
     `,
-    args: [address],
+    args: [accountAddress],
   })
 
   return {
-    publicPaths: reduce(result.public),
-    privatePaths: reduce(result.private),
-    storagePaths: reduce(result.storage),
+    publicPaths: reduceValues(result.public, useSet),
+    privatePaths: reduceValues(result.private, useSet),
+    storagePaths: reduceValues(result.storage, useSet),
   }
 }
 
+/**
+ * Retrieves public, private, and storage paths for a given account with extra information available on them
+ *
+ * @async
+ * @param {string} account - The address of the account to retrieve path information for.
+ * @returns {Promise<{
+ *   publicPaths: {[key: string]: {[key: string]: any}},
+ *   privatePaths: {[key: string]: {[key: string]: any}},
+ *   storagePaths: {[key: string]: {[key: string]: any}}
+ * }>} An object containing objects with the types of the public, private, and storage paths for the account.
+ */
+export async function getPathsWithType(account) {
+  let accountAddress = account
+  if (!isAddress(accountAddress)) {
+    accountAddress = await getAccountAddress(account)
+  }
+  const [result] = await executeScript({
+    code: `
+      pub fun main(address: Address): {String: {String: AnyStruct}} {
+        let account = getAuthAccount(address)
+        var res: {String: {String: AnyStruct}} = {}
+               
+        // Iterate over public
+        let public: {String: AnyStruct} = {}
+        account.forEachPublic(fun (path:PublicPath, type: Type): Bool{
+          public[path.toString()] = type
+          return true
+        })
+        
+        // Iterate over public
+        let private: {String: AnyStruct} = {}
+        account.forEachPrivate(fun (path:PrivatePath, type: Type): Bool{
+          private[path.toString()] = type
+          return true
+        })
+        
+        // Iterate over storage paths
+        let storage: {String: AnyStruct} = {}
+        account.forEachStored(fun (path:StoragePath, type: Type): Bool{
+          storage[path.toString()] = type
+          return true
+        })
+        
+        res["publicPaths"] = public
+        res["privatePaths"] = private
+        res["storagePaths"] = storage
+        
+        return res
+      }
+    `,
+    args: [accountAddress],
+  })
+
+  return processValues(result)
+}
+
+/**
+ * Retrieves the storage value at a given path for a given account.
+ *
+ * @async
+ * @param {string} account - The address or name of the account to retrieve the storage value from.
+ * @param {string} path - The path of the storage value to retrieve.
+ * @returns {Promise<any>} The value of the storage at the given path, or `null` if no value is found.
+ */
 export async function getStorageValue(account, path) {
+  let accountAddress = account
+  if (!isAddress(accountAddress)) {
+    accountAddress = await getAccountAddress(account)
+  }
+
   let fixedPath = path.startsWith("/") ? path.slice(1) : path
   let storagePath = `/storage/${fixedPath}`
-  const args = [account, storagePath]
   const code = `
     import MetadataViews from 0x1
     
@@ -96,6 +237,49 @@ export async function getStorageValue(account, path) {
       return nil
     }
   `
-  const [values, error] = await executeScript({code, args})
-  return [values, error]
+  const args = [accountAddress, storagePath]
+
+  const [values] = await executeScript({code, args})
+  return values
+}
+
+/**
+ * Retrieves the storage statistics (used and capacity) for a given account.
+ *
+ * @async
+ * @param {string} address - The address of the account to retrieve storage statistics for.
+ * @param {boolean} [convert=true] - Whether to convert the returned statistics from `UInt64` to `number`.
+ * @returns {Promise<{
+ *   used: number | string,
+ *   capacity: number | string
+ * }>} An object containing the used and capacity storage statistics for the account.
+ */
+export async function getStorageStats(address, convert = true) {
+  let accountAddress = address
+  if (!isAddress(accountAddress)) {
+    accountAddress = await getAccountAddress(address)
+  }
+
+  const [result] = await executeScript({
+    code: `
+      pub fun main(address: Address): {String: UInt64} {
+        let account = getAuthAccount(address)
+        
+        return {
+          "used": account.storageUsed,
+          "capacity": account.storageCapacity
+        }
+      }
+    `,
+    args: [accountAddress],
+  })
+
+  if (convert) {
+    return {
+      used: parseInt(result.used),
+      capacity: parseInt(result.capacity),
+    }
+  }
+
+  return result
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -40,3 +40,38 @@ export function getAvailablePorts(count = 1) {
 export const getServiceAddress = async () => {
   return withPrefix(await config().get("SERVICE_ADDRESS"))
 }
+
+export function parsePath(path) {
+  const rxResult = /(\w+)\/(\w+)/.exec(path)
+  if (!rxResult) {
+    throw Error(`${path} is not a correct path`)
+  }
+
+  return {
+    domain: rxResult[1],
+    slot: rxResult[2],
+  }
+}
+export const getValueByKey = (keys, value) => {
+  if (!value) {
+    return null
+  }
+
+  if (keys.length > 0 && !isObject(value)) {
+    return null
+  }
+
+  if (typeof keys === "string") {
+    return getValueByKey(keys.split("."), value)
+  }
+  const [first, ...rest] = keys
+
+  if (!first) {
+    return value
+  }
+
+  if (!rest) {
+    return value[first]
+  }
+  return getValueByKey(rest, value[first])
+}

--- a/test/integration/storage.test.js
+++ b/test/integration/storage.test.js
@@ -6,10 +6,16 @@ import {
   shallPass,
   sendTransaction,
 } from "../../src"
-import {getPaths, getStorageValue} from "../../src/storage"
+import {
+  getPaths,
+  getPathsWithType,
+  getStorageStats,
+  getStorageValue,
+} from "../../src/storage"
+import {shallHavePath, shallHaveStorageValue} from "../../src/jest-asserts"
 
 // We need to set timeout for a higher number, because some transactions might take up some time
-jest.setTimeout(10000)
+jest.setTimeout(50000)
 
 beforeEach(async () => {
   const basePath = path.resolve(__dirname, "../cadence")
@@ -23,8 +29,8 @@ afterEach(async () => {
   emulator.stop()
 })
 
-describe("Basic Usage test", () => {
-  test("Basic inspection", async () => {
+describe("Storage Inspection", () => {
+  test("Paths inspection", async () => {
     const Alice = await getAccountAddress("Alice")
     const {publicPaths, privatePaths, storagePaths} = await getPaths(Alice)
 
@@ -38,7 +44,6 @@ describe("Basic Usage test", () => {
     expect(storagePaths.size).toBe(1)
     expect(storagePaths.has("flowTokenVault")).toBe(true)
   })
-
   test("Reading storage values", async () => {
     const Alice = await getAccountAddress("Alice")
     await shallPass(
@@ -54,12 +59,71 @@ describe("Basic Usage test", () => {
       })
     )
     const {storagePaths} = await getPaths(Alice)
-    const [vault] = await getStorageValue(Alice, "flowTokenVault")
-    const [answer] = await getStorageValue(Alice, "answer")
+    const vault = await getStorageValue(Alice, "flowTokenVault")
+    const answer = await getStorageValue("Alice", "answer")
+    const empty = await getStorageValue(Alice, "empty")
 
     expect(storagePaths.has("answer")).toBe(true)
     expect(vault.balance).toBe("0.00100000")
     expect(answer).toBe("42")
     expect(answer).not.toBe(1337)
+    expect(empty).toBe(null)
+  })
+  test("Reading types", async () => {
+    const {publicPaths} = await getPathsWithType("Alice")
+    const refTokenBalance = publicPaths.flowTokenBalance
+
+    expect(refTokenBalance).not.toBe(undefined)
+    expect(
+      refTokenBalance.restrictionsList.has(
+        "A.ee82856bf20e2aa6.FungibleToken.Balance"
+      )
+    ).toBe(true)
+    expect(refTokenBalance.restrictionsList.size).toBe(1)
+    expect(refTokenBalance.haveRestrictions("FungibleToken.Balance")).toBe(true)
+  })
+  test("Read storage stats", async () => {
+    const {capacity, used} = await getStorageStats("Alice")
+
+    expect(capacity).toBe(100000)
+    expect(used > 0).toBe(true)
+  })
+  test("Jest helper - shallHavePath - pass name", async () => {
+    await shallHavePath("Alice", "/storage/flowTokenVault")
+  })
+  test("Jest helper - shallHavePath - pass address", async () => {
+    const Alice = await getAccountAddress("Alice")
+    await shallHavePath(Alice, "/storage/flowTokenVault")
+  })
+  test("Jest helper - shallHaveStorageValue - check simple storage value", async () => {
+    const expectedValue = 42
+    const pathName = "answer"
+
+    const Alice = await getAccountAddress("Alice")
+    await shallPass(
+      sendTransaction({
+        code: `
+        transaction{
+          prepare(signer: AuthAccount){
+            signer.save(${expectedValue}, to: /storage/${pathName})
+          }
+        }
+      `,
+        signers: [Alice],
+      })
+    )
+
+    await shallHaveStorageValue(Alice, {
+      pathName,
+      expect: expectedValue.toString(),
+    })
+  })
+  test("Jest helper - shallHaveStorageValue - check complex storage value", async () => {
+    const Alice = await getAccountAddress("Alice")
+    await shallHaveStorageValue(Alice, {
+      pathName: "flowTokenVault",
+      key: "balance",
+      expect: "0.00100000",
+    })
   })
 })

--- a/test/integration/storage.test.js
+++ b/test/integration/storage.test.js
@@ -1,0 +1,65 @@
+import path from "path"
+import {
+  emulator,
+  init,
+  getAccountAddress,
+  shallPass,
+  sendTransaction,
+} from "../../src"
+import {getPaths, getStorageValue} from "../../src/storage"
+
+// We need to set timeout for a higher number, because some transactions might take up some time
+jest.setTimeout(10000)
+
+beforeEach(async () => {
+  const basePath = path.resolve(__dirname, "../cadence")
+  await init(basePath)
+  return emulator.start({
+    flags: "--contracts",
+  })
+})
+
+afterEach(async () => {
+  emulator.stop()
+})
+
+describe("Basic Usage test", () => {
+  test("Basic inspection", async () => {
+    const Alice = await getAccountAddress("Alice")
+    const {publicPaths, privatePaths, storagePaths} = await getPaths(Alice)
+
+    // Newly created account shall have 2 public and 1 storage slot occupied for FLOW Vault
+    expect(publicPaths.size).toBe(2)
+    expect(publicPaths.has("flowTokenBalance")).toBe(true)
+    expect(publicPaths.has("flowTokenReceiver")).toBe(true)
+
+    expect(privatePaths.size).toBe(0)
+
+    expect(storagePaths.size).toBe(1)
+    expect(storagePaths.has("flowTokenVault")).toBe(true)
+  })
+
+  test("Reading storage values", async () => {
+    const Alice = await getAccountAddress("Alice")
+    await shallPass(
+      sendTransaction({
+        code: `
+        transaction{
+          prepare(signer: AuthAccount){
+            signer.save(42, to: /storage/answer)
+          }
+        }
+      `,
+        signers: [Alice],
+      })
+    )
+    const {storagePaths} = await getPaths(Alice)
+    const [vault] = await getStorageValue(Alice, "flowTokenVault")
+    const [answer] = await getStorageValue(Alice, "answer")
+
+    expect(storagePaths.has("answer")).toBe(true)
+    expect(vault.balance).toBe("0.00100000")
+    expect(answer).toBe("42")
+    expect(answer).not.toBe(1337)
+  })
+})

--- a/test/util/index.test.js
+++ b/test/util/index.test.js
@@ -1,0 +1,36 @@
+import {getValueByKey} from "../../src/utils"
+
+describe("testing utilities", function () {
+  test("extract object value - simple key", () => {
+    const expected = 42
+
+    const key = "answer"
+    const obj = {
+      [key]: expected,
+    }
+    const actual = getValueByKey(key, obj)
+    expect(actual).toBe(expected)
+  })
+  test("extract object value - nested key", () => {
+    const expected = 42
+
+    const key = "some.nested.value"
+    const obj = {
+      some: {
+        nested: {
+          value: expected,
+        },
+      },
+    }
+    const actual = getValueByKey(key, obj)
+    expect(actual).toBe(expected)
+  })
+  test("extract object value - not an object", () => {
+    const expected = null
+
+    const key = "some.nested.value"
+    const obj = "not an object"
+    const actual = getValueByKey(key, obj)
+    expect(actual).toBe(expected)
+  })
+})


### PR DESCRIPTION
Work in progress for #205 

## Description
This PR adds multiple new methods to query storage:
- `getPaths` - returning an object containing paths for public, private and storage domains
- `getPathsWithType` - same as above, but with more detailed info about Capabilities
- `getStorageValue` - returning value at specified storage path
- `getStorageStats` - used and storage capacity info

Jest helpers added:
- `shallHavePath` - checks that account have path on specified domain
- `shallHaveStorageValue` - checks that account have specific value stored

### Documentation
Updated documentation:
- API reference for newly added functions
- Jest Asserts documentation 

### Tests
All new methods are covered with tests.

### Changeset:
Changeset for new minor version is included

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-js-testing/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
