### PR TITLE
Enable coverage reporting for Flow Emulator

### DIFF
--- a/src/emulator/emulator.js
+++ b/src/emulator/emulator.js
@@ -109,6 +109,7 @@ More info: https://github.com/onflow/flow-js-testing/blob/master/TRANSITIONS.md#
       `--admin-port=${this.adminPort}`,
       `--port=${this.grpcPort}`,
       `--skip-version-check`,
+      `--coverage-reporting=true`,
       signatureCheck ? "" : "--skip-tx-validation",
       flags,
     ])


### PR DESCRIPTION
Work towards: https://github.com/onflow/developer-grants/issues/132

## Description

Sets the newly-added `--coverage-reporting` flag, when spawning a new child process for Flow Emulator.
With this flag set to `true`, developers can issue an HTTP call to http://localhost:8080/emulator/codeCoverage, and retrieve the Coverage Report in a JSON format (see https://github.com/Build-Squad/flow-code-coverage#for-emulator for more info).
My understanding is that the `Emulator` class, will have to keep an object representing the JSON response from the above HTTP endpoint, and on every call of `Emulator.stop()` method, there should be a merging of these reports.
Finally, this report can be written in a local file.

---

For contributor use:

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Code follows the [standards mentioned here](https://github.com/onflow/flow-js-testing/blob/master/CONTRIBUTING.md#styleguides)
- [x] Updated relevant documentation
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Added appropriate labels
