### PR TITLE
fix short-hand-import parser

### DIFF
--- a/src/imports.js
+++ b/src/imports.js
@@ -29,7 +29,7 @@ const importRegex = new RegExp(
 export const fixShorthandImports = code => {
   return code.replaceAll(importRegex, found => {
     if (found.indexOf(" from") !== -1) return found
-    const whatMatch = found.matchAll(/"?([^"\s]+)"?,?\s*?/giu)
+    const whatMatch = found.matchAll(/"([^"\s]+)"\s*,?\s*?/giu)
     return [...whatMatch]
       .map(what => `import ${what[1]} from "./${what[1]}.cdc"`)
       .join("\n")

--- a/test/integration/imports.test.js
+++ b/test/integration/imports.test.js
@@ -8,6 +8,7 @@ import {
 } from "../../src"
 import {defaultsByName} from "../../src/file"
 import {DEFAULT_TEST_TIMEOUT} from "../util/timeout.const"
+import {fixShorthandImports} from "../../src/imports"
 
 jest.setTimeout(DEFAULT_TEST_TIMEOUT)
 
@@ -48,6 +49,9 @@ describe("import resolver", () => {
             
             access(all) fun main(){}
         `
+
+    const testFixed = fixShorthandImports(code)
+    expect(testFixed.includes("import.cdc")).toBe(false)
 
     const addressMap = await resolveImports(code)
     const Registry = await getServiceAddress()


### PR DESCRIPTION
Fix for short-hand-import parser erroneously treating the `import` keyword as one of the contracts to be imported.

Fixes this symptom:
```

    error: [Error Code: 1054] location (./import.cdc) is not a valid location: expecting an AddressLocation, but other location types are passed
    --> ./import.cdc

```

