### PR TITLE
Fix getFlowVersion

### DIFF
--- a/.changeset/nasty-otters-chew.md
+++ b/.changeset/nasty-otters-chew.md
@@ -1,0 +1,5 @@
+---
+"@onflow/flow-js-testing": patch
+---
+
+Add fallback for version checking CLI when JSON not supported

--- a/src/utils.js
+++ b/src/utils.js
@@ -53,20 +53,17 @@ export async function getFlowVersion(flowCommand = "flow") {
         )
       } else {
         let versionStr
-        const rxResult = /^Version: ([^\s]+)/m.exec(stdout)
-        if (rxResult) {
+        try {
+          versionStr = JSON.parse(stdout).version
+        } catch (error) {
+          // fallback to regex for older versions of the CLI without JSON output
+          const rxResult = /^Version: ([^\s]+)/m.exec(stdout)
+          if (rxResult) {
             versionStr = rxResult[1]
+          }
         }
-        else {
-            try {
-                versionStr = JSON.parse(stdout).version
-            }
-            catch(error) {
-                // stdout is not a JSON
-            }
-        }
-        
-        const version = versionStr ? semver.parse(versionStr) : undefined;
+
+        const version = versionStr ? semver.parse(versionStr) : undefined
         if (!version) {
           reject(`Invalid Flow CLI version string: ${versionStr}`)
         }

--- a/src/utils.js
+++ b/src/utils.js
@@ -52,8 +52,21 @@ export async function getFlowVersion(flowCommand = "flow") {
           "Could not determine Flow CLI version, please make sure it is installed and available in your PATH"
         )
       } else {
-        const versionStr = JSON.parse(stdout).version
-        const version = semver.parse(versionStr)
+        let versionStr
+        const rxResult = /^Version: ([^\s]+)/m.exec(stdout)
+        if (rxResult) {
+            versionStr = rxResult[1]
+        }
+        else {
+            try {
+                versionStr = JSON.parse(stdout).version
+            }
+            catch(error) {
+                // stdout is not a JSON
+            }
+        }
+        
+        const version = versionStr ? semver.parse(versionStr) : undefined;
         if (!version) {
           reject(`Invalid Flow CLI version string: ${versionStr}`)
         }


### PR DESCRIPTION
Fix getFlowVersion to work with the lastest Flow CLI.
Fixing the issue reported here https://github.com/onflow/flow-js-testing/issues/233

---

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-js-testing/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels
